### PR TITLE
fix compiler warnings and remove whitespaces

### DIFF
--- a/lib/stripe/cards.ex
+++ b/lib/stripe/cards.ex
@@ -34,7 +34,7 @@ defmodule Stripe.Cards do
 
   @doc """
   Create a card.
-  
+
   Creates a card for given owner type, owner ID using params.
 
   `params` must contain a "source" object. Inside the "source" object, the following parameters are required:
@@ -186,8 +186,8 @@ defmodule Stripe.Cards do
       {:ok, cards} = Stripe.Cards.list(:customer, customer_id, 5, 20) # Get a list of up to 20 cards, skipping first 5 cards
 
   """
-  def list(owner_type, owner_id, starting_after, limit \\ 10) do
-    list owner_type, owner_id, Stripe.config_or_env_key, "", limit
+  def list(owner_type, owner_id, starting_after \\ "", limit \\ 10) do
+    list owner_type, owner_id, Stripe.config_or_env_key, starting_after, limit
   end
 
   @doc """
@@ -244,7 +244,7 @@ defmodule Stripe.Cards do
     Stripe.make_request_with_key(:delete, "#{endpoint_for_entity(owner_type, owner_id)}/#{id}", key)
     |> Stripe.Util.handle_stripe_response
   end
-  
+
   @doc """
   Delete all cards.
 
@@ -303,7 +303,7 @@ defmodule Stripe.Cards do
 
       {:ok, cards} = Stripe.Cards.all(:customer, customer_id, accum, starting_after)
 
-  """  
+  """
   def all(owner_type, owner_id, accum \\ [], starting_after \\ "") do
     all owner_type, owner_id, Stripe.config_or_env_key, accum, starting_after
   end
@@ -324,7 +324,7 @@ defmodule Stripe.Cards do
 
       {:ok, cards} = Stripe.Cards.all(:customer, customer_id, accum, starting_after, key)
 
-  """  
+  """
   def all(owner_type, owner_id, key, accum, starting_after) do
     case Stripe.Util.list_raw("#{endpoint_for_entity(owner_type, owner_id)}",key, @max_fetch_size, starting_after) do
       {:ok, resp}  ->

--- a/lib/stripe/connect.ex
+++ b/lib/stripe/connect.ex
@@ -19,7 +19,6 @@ defmodule Stripe.Connect do
   crsf token to be sent to stripe, which they send you back at the end of the workflow to further secure the interaction. Make sure you verify this token yourself on reception of the workflow callback.
   """
   def generate_button_url( csrf_token ) do
-    client_id = Stripe.config_or_env_platform_client_id
     url = base_url() <> "oauth/authorize?response_type=code"
     url = url <> "&scope=read_write"
     url = url <> "&client_id=#{Stripe.config_or_env_platform_client_id}"
@@ -33,21 +32,21 @@ defmodule Stripe.Connect do
 
   @doc """
   Execute the oauth callback to Stripe using the code supplied in the request parameter of the oauth redirect at the end of the onboarding workflow.
-# Example
-```
-{:ok, resp} = Stripe.Connect.oauth_token_callback code
-IO.inspect resp
-%{
-    token_type: "bearer",
-    stripe_publishable_key: "PUBLISHABLE_KEY",
-    scope: "read_write",
-    livemode: false,
-    stripe_user_id: "USER_ID",
-    refresh_token: "REFRESH_TOKEN",
-    access_token: "ACCESS_TOKEN"
-}
+  # Example
+  ```
+  {:ok, resp} = Stripe.Connect.oauth_token_callback code
+  IO.inspect resp
+  %{
+      token_type: "bearer",
+      stripe_publishable_key: "PUBLISHABLE_KEY",
+      scope: "read_write",
+      livemode: false,
+      stripe_user_id: "USER_ID",
+      refresh_token: "REFRESH_TOKEN",
+      access_token: "ACCESS_TOKEN"
+  }
 
-```
+  ```
 
   """
   def oauth_token_callback(code) do
@@ -97,7 +96,7 @@ IO.inspect resp
 
     case body[:stripe_user_id] == stripe_user_id do
         true -> {:ok, true}
-        false -> {:error, body[:error_description]}  
+        false -> {:error, body[:error_description]}
     end
   end
 end

--- a/lib/stripe/customers.ex
+++ b/lib/stripe/customers.ex
@@ -131,8 +131,8 @@ defmodule Stripe.Customers do
     {:ok, customers} = Stripe.Customers.list(starting_after, 20)
   ```
   """
-  def list(starting_after,limit \\ 10) do
-    list Stripe.config_or_env_key, "", limit
+  def list(starting_after \\ "", limit \\ 10) do
+    list Stripe.config_or_env_key, starting_after, limit
   end
 
   @doc """

--- a/lib/stripe/invoices.ex
+++ b/lib/stripe/invoices.ex
@@ -8,7 +8,7 @@
 
   All calls have a version with accept a key parameter for leveraging Connect.
 
-  (API ref:https://stripe.com/docs/api#invoices) 
+  (API ref:https://stripe.com/docs/api#invoices)
   """
 
   @endpoint "invoices"
@@ -31,42 +31,42 @@
     |> Stripe.Util.handle_stripe_response
   end
 
-  @doc """
-  Returns a list of invoices for a given customer
+  # @doc """
+  # Returns a list of invoices for a given customer
 
-  ## Example
+  # ## Example
 
-  ```
-  {:ok, invoices} = Stripe.Customers.get_invoices "customer_id"
-  ```
+  # ```
+  # {:ok, invoices} = Stripe.Customers.get_invoices "customer_id"
+  # ```
 
-  """
- # def get_invoices(id, params \\ []) do
- #   get_invoices id, params, Stripe.config_or_env_key
- # end
+  # """
+  # def get_invoices(id, params \\ []) do
+  #   get_invoices id, params, Stripe.config_or_env_key
+  # end
 
-  @doc """
-  Returns a list of invoices for a given customer
-  Using a given stripe key to apply against the account associated.
+  # @doc """
+  # Returns a list of invoices for a given customer
+  # Using a given stripe key to apply against the account associated.
 
-  ## Example
+  # ## Example
 
-  ```
-  {:ok, invoices} = Stripe.Customers.get_invoices "customer_id", key
-  ```
-  """
- # def get_invoices(id, params, key) do
- #   params = Keyword.put_new params, :limit, 10
- #   params = Keyword.put_new params, :customer, id
- #   Stripe.Util.list "invoices", key, starting_after, limit
- # end
+  # ```
+  # {:ok, invoices} = Stripe.Customers.get_invoices "customer_id", key
+  # ```
+  # """
+  # def get_invoices(id, params, key) do
+  #   params = Keyword.put_new params, :limit, 10
+  #   params = Keyword.put_new params, :customer, id
+  #   Stripe.Util.list "invoices", key, starting_after, limit
+  # end
 
   @doc """
   Count number of invoices.
   ## Example
 
   ```
-  {:ok, cnt} = Stripe.Invoices.count 
+  {:ok, cnt} = Stripe.Invoices.count
   ```
   """
   def count do
@@ -79,7 +79,7 @@
   ## Example
 
   ```
-  {:ok, cnt} = Stripe.Invoices.count key 
+  {:ok, cnt} = Stripe.Invoices.count key
   ```
   """
   def count(key) do

--- a/lib/stripe/subscriptions.ex
+++ b/lib/stripe/subscriptions.ex
@@ -16,7 +16,7 @@ defmodule Stripe.Subscriptions do
   @endpoint "customers"
 
   @doc """
-  Starts a subscription for the specified customer. 
+  Starts a subscription for the specified customer.
 
   ## Example
 
@@ -35,7 +35,7 @@ defmodule Stripe.Subscriptions do
   end
 
   @doc """
-  Starts a subscription for the specified customer using given api key. 
+  Starts a subscription for the specified customer using given api key.
 
   ## Example
 
@@ -50,8 +50,6 @@ defmodule Stripe.Subscriptions do
   ```
   """
   def create(customer_id, opts, key) do
-    plan_id = Keyword.get opts, :plan
-
     Stripe.make_request_with_key(:post, "#{@endpoint}/#{customer_id}/subscriptions", key, opts)
     |> Stripe.Util.handle_stripe_response
   end
@@ -154,7 +152,7 @@ defmodule Stripe.Subscriptions do
     Stripe.make_request_with_key(:delete, "#{@endpoint}/#{customer_id}/subscriptions/#{sub_id}", key, opts)
     |> Stripe.Util.handle_stripe_response
   end
-  
+
   @doc """
   Cancel all subscriptions for account.
 

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -79,5 +79,5 @@ defmodule Stripe.Util do
         {:ok, res[:total_count]}
       {:error, err} -> raise err
     end
-end
+  end
 end


### PR DESCRIPTION
This PR addresses a bunch of compiler warnings and removes some whitespace:
![warnings](https://dl.dropboxusercontent.com/s/hm834w87n5jfuor/2016-11-10%20at%206.15%20PM.png)