### PR TITLE
Fix the way that client ID is fetched

### DIFF
--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -13,14 +13,6 @@ defmodule Stripe.Connect.OAuth do
 
   alias Stripe.Util
 
-  @client_id Application.get_env(:stripity_stripe, :connect_client_id)
-  @client_secret Application.get_env(:stripity_stripe, :api_key)
-
-  @authorize_url_base_params %{
-    client_id: @client_id,
-    response_type: "code",
-    scope: "read_write"
-  }
 
   @authorize_url_valid_keys [
    :always_prompt,
@@ -92,7 +84,7 @@ defmodule Stripe.Connect.OAuth do
     endpoint = "token"
 
     body = %{
-      client_secret: @client_secret,
+      client_secret: get_client_secret(),
       code: code,
       grant_type: "authorization_code"
     }
@@ -112,12 +104,13 @@ defmodule Stripe.Connect.OAuth do
   ```
   iex(1)> {:ok, result} = Stripe.Connect.OAuth.deauthorize(stripe_user_id)
   ```
+  
   """
   @spec deauthorize(String.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
   def deauthorize(stripe_user_id) do
     endpoint = "deauthorize"
     body = %{
-      client_id: @client_id,
+      client_id: get_client_id(),
       stripe_user_id: stripe_user_id
     }
 
@@ -152,7 +145,7 @@ defmodule Stripe.Connect.OAuth do
 
   ```
   %{
-    client_id: @client_id, # :connect_client_id from configuration
+    client_id: client_id, # :connect_client_id from configuration
     response_type: "code",
     scope: "read_write"
   }
@@ -187,11 +180,30 @@ defmodule Stripe.Connect.OAuth do
     base_url = "https://connect.stripe.com/oauth/authorize?"
 
     param_string =
-      @authorize_url_base_params
+      get_default_authorize_map()
       |> Map.merge(options)
       |> Map.take(@authorize_url_valid_keys)
       |> Stripe.URI.encode_query()
 
     base_url <> param_string
+  end
+
+  @spec get_client_id() :: String.t
+  defp get_client_id() do
+    Application.get_env(:stripity_stripe, :connect_client_id)
+  end
+
+  @spec get_client_secret() :: String.t
+  defp get_client_secret() do
+    Application.get_env(:stripity_stripe, :api_key)
+  end
+
+  @spec get_default_authorize_map() :: map
+  defp get_default_authorize_map() do
+    %{
+      client_id: get_client_id(),
+      response_type: "code",
+      scope: "read_write"
+    }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Stripe.Mixfile do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls],
-      version: "2.0.0-alpha.4"
+      version: "2.0.0-alpha.5"
     ]
   end
 


### PR DESCRIPTION
@JoshSmith This should fix the issue you're having with client IDs being nil.

The problem was that module attributes are determined at compile time, which means that it's the value that the system thinks is there at compile time. On Heroku this gets strange because of the way it manages environment variables during the buildphase. See this documentation specifically: https://github.com/HashNuke/heroku-buildpack-elixir#specifying-config-vars-to-export-at-compile-time

This fixes the library so that you don't need to worry about all that. It will fetch the actual runtime configuration values instead of the compile time configuration values.