### PR TITLE
Adding ability to update Customer source

### DIFF
--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -42,12 +42,12 @@ defmodule Stripe.Customer do
 
   @valid_create_keys [
     :account_balance, :business_vat_id, :coupon, :description, :email,
-    :metadata, :plan, :quantity, :tax_percent, :trial_end
+    :metadata, :plan, :quantity, :tax_percent, :trial_end, :source
   ]
 
   @valid_update_keys [
     :account_balance, :business_vat_id, :coupon, :default_source, :description,
-    :email, :metadata
+    :email, :metadata, :source
   ]
 
   @doc """


### PR DESCRIPTION
The `source` parameter, which is a Stripe token ID, can be provided when creating or updating a Customer to automatically create a card and set the Customer's `default_source` to this card.