### PR TITLE
Add Account.create

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -19,7 +19,7 @@ defmodule Stripe.Account do
   defstruct [
     :id, :business_name, :business_primary_color, :business_url,
     :charges_enabled, :country, :default_currency, :details_submitted,
-    :display_name, :email, :managed, :metadata, :statement_descriptor,
+    :display_name, :email, :legal_entity, :managed, :metadata, :statement_descriptor,
     :support_email, :support_phone, :support_url, :timezone,
     :transfers_enabled
   ]
@@ -42,17 +42,28 @@ defmodule Stripe.Account do
     support_phone: :string,
     support_url: :string,
     timezone: :string,
-    transfers_enabled: :boolean
+    transfers_enabled: :boolean,
+    legal_entity: %{module: Stripe.Account.LegalEntity}
   }
 
   @singular_endpoint "account"
   @plural_endpoint "accounts"
+
+  @valid_create_keys [:country, :email, :managed, :legal_entity]
 
   @doc """
   Returns the Stripe response mapping of keys to types.
   """
   @spec response_mapping :: Keyword.t
   def response_mapping, do: @response_mapping
+
+  @doc """
+  Create an account.
+  """
+  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(account, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, account, @valid_create_keys, __MODULE__, opts)
+  end
 
   @doc """
   Retrieve your own account without options.

--- a/lib/stripe/account/address.ex
+++ b/lib/stripe/account/address.ex
@@ -1,0 +1,31 @@
+defmodule Stripe.Account.Address do
+  @moduledoc """
+  Module definition for a Stripe Address object
+  Stripe Address objects do not have endpoints or actions associated,
+  but they have a specific mapping
+  """
+
+  alias Stripe.Util
+
+  @type t :: %__MODULE__{}
+
+  defstruct [
+    :city, :country, :line1, :line2, :state, :postal_code
+  ]
+
+  @response_mapping %{
+    city: :string,
+    country: :string,
+    line1: :string,
+    line2: :string,
+    state: :string,
+    postal_code: :string,
+
+  }
+
+  @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
+end

--- a/lib/stripe/account/date.ex
+++ b/lib/stripe/account/date.ex
@@ -1,0 +1,25 @@
+ defmodule Stripe.Account.Date do
+  @moduledoc """
+  Module definition for a Stripe Date object
+  Stripe Date objects do not have endpoints or actions associated,
+  but they have a specific mapping
+  """
+
+  alias Stripe.Util
+
+  @type t :: %__MODULE__{}
+
+  defstruct [:day, :month, :year]
+
+  @response_mapping %{
+    day: :integer,
+    month: :integer,
+    year: :integer
+  }
+
+  @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
+end

--- a/lib/stripe/account/legal_entity.ex
+++ b/lib/stripe/account/legal_entity.ex
@@ -1,0 +1,34 @@
+defmodule Stripe.Account.LegalEntity do
+  @moduledoc """
+  Module definition for a Stripe LegalEntity object
+  Stripe LegalEntity objects do not have endpoints or actions associated,
+  but they have a specific mapping
+  """
+
+  alias Stripe.Util
+
+  @type t :: %__MODULE__{}
+
+  defstruct [
+    :business_name, :business_tax_id_provided, :dob, :first_name, :last_name,
+    :address, :personal_address, :ssn_last_4_provided, :type
+  ]
+
+  @response_mapping %{
+    business_name: :string,
+    business_tax_id_provided: :boolean,
+    dob: %{module: Stripe.Account.Date},
+    first_name: :string,
+    last_name: :string,
+    address: %{module: Stripe.Account.Address},
+    personal_address: %{module: Stripe.Account.Address},
+    ssn_last_4_provided: :boolean,
+    type: :string
+  }
+
+  @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
+end

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -9,7 +9,9 @@ defmodule Stripe.Request do
       |> Util.drop_nil_keys()
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Util.stripe_map_to_struct(module, result)}
+      {:ok, result} ->
+        IO.inspect(result, pretty: true)
+        {:ok, Util.stripe_map_to_struct(module, result)}
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -18,7 +18,7 @@ defmodule Stripe.Util do
   end
 
   defp convert_value(key, format, map) when is_map(format) do
-    stripe_map_to_struct(format.module, map)
+    stripe_map_to_struct(format.module, map |> Map.get(key))
   end
   defp convert_value(key, :metadata, map) do
     map


### PR DESCRIPTION
This is a WIP of adding a `Stripe.Account.create` action

I was implementing this while attempting to make a code spike to switch to managed accounts in our project, so as such, it only does the bare minimum I needed to get through the process.

It still requires a good amount of wrapping up and probably discussion.

The biggest point of discussion is how to organise the many "subobjects" an `Account` object contains, such as the address, the legal entity, the verification, tos and date hashes, etc.

For now, I'm making use of the typical conversion we have and defining minor modules under the `Stripe.Account` namespace. This means at that the moment, we have

* `Stripe.Account.LegalEntity`
* `Stripe.Account.Date` (literally a hash of day, month and year)
* `Stripe.Account.Address`

If we follow this approach, we will also need

* `Stripe.Account.Verification`
* `Stripe.Account.TosAcceptance`
* etc.

Each module defines its fields and response mapping, but does not define any operations (for obvious reasons).