### PR TITLE
Add Account.create/2

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -29,6 +29,8 @@ defmodule Stripe.Account do
   @singular_endpoint "account"
   @plural_endpoint "accounts"
 
+  @valid_create_keys [:country, :email, :managed]
+
   @doc """
   Returns a map of relationship keys and their Struct name.
   Relationships must be specified for the relationship to
@@ -36,6 +38,14 @@ defmodule Stripe.Account do
   """
   @spec relationships :: Keyword.t
   def relationships, do: @relationships
+
+  @doc """
+  Create an account.
+  """
+  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(account, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, account, @valid_create_keys, __MODULE__, opts)
+  end
 
   @doc """
   Retrieve your own account without options.


### PR DESCRIPTION
Adds a basic `Account.create/2` endpoint.

Only supports the basic create keys specified by https://stripe.com/docs/api#create_account

However, the documentation specifies that all the update keys are also valid. I'm unsure of the best way to handle that, but it can be done separately.