### PR TITLE
Add update changesets

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -29,14 +29,122 @@ defmodule Stripe.Account do
   @singular_endpoint "account"
   @plural_endpoint "accounts"
 
-  @valid_create_keys [:country, :email, :managed]
+  @address_map %{
+    city: [:create, :retrieve, :update],
+    country: [:create, :retrieve, :update],
+    line1: [:create, :retrieve, :update],
+    line2: [:create, :retrieve, :update],
+    postal_code: [:create, :retrieve, :update],
+    state: [:create, :retrieve, :update]
+  }
 
-  @valid_update_keys [
-    :business_logo, :business_name, :business_primary_color, :business_url,
-    :debit_negative_balances, :decline_charge_on, :default_currency, :email,
-    :external_account, :legal_entity, :metadata, :product_description,
-    :statement_descriptor, :support_email, :support_phone, :support_url,
-    :tos_acceptance, :transfer_schedule, :transfer_statement_descriptor
+  @address_kana_kanji_map %{ # Japan only
+    city: [:create, :retrieve, :update],
+    country: [:create, :retrieve, :update],
+    line1: [:create, :retrieve, :update],
+    line2: [:create, :retrieve, :update],
+    postal_code: [:create, :retrieve, :update],
+    state: [:create, :retrieve, :update],
+    town: [:create, :retrieve, :update]
+  }
+
+  @dob_map %{
+    day: [:create, :retrieve, :update],
+    month: [:create, :retrieve, :update],
+    year: [:create, :retrieve, :update]
+  }
+
+  @schema %{
+    business_logo: [:create, :retrieve, :update],
+    business_name: [:create, :retrieve, :update],
+    business_primary_color: [:create, :retrieve, :update],
+    business_url: [:create, :retrieve, :update],
+    country: [:create, :retrieve],
+    debit_negative_balances: [:create, :retrieve, :update],
+    decline_charge_on: %{
+      avs_failure: [:create, :retrieve, :update],
+      cvc_failure: [:create, :retrieve, :update]
+    },
+    default_currency: [:create, :retrieve, :update],
+    email: [:create, :retrieve, :update],
+    # TODO: Add ability to have nested external_account object OR the
+    # token string – can accomplish with a tuple and matching on that.
+    external_account: [:create, :retrieve, :update],
+    external_accounts: [:retrieve],
+    id: [:retrieve],
+    legal_entity: %{
+      address: @address_map,
+      address_kana: @address_kana_kanji_map, # Japan only
+      address_kanji: @address_kana_kanji_map, # Japan only
+      business_name: [:create, :retrieve, :update],
+      business_name_kana: [:create, :retrieve, :update], # Japan only
+      business_name_kanji: [:create, :retrieve, :update], # Japan only
+      business_tax_id: [:create, :update],
+      business_tax_id_provided: [:retrieve],
+      business_vat_id: [:create, :update],
+      business_vat_id_provided: [:retrieve],
+      dob: @dob_map,
+      first_name: [:create, :retrieve, :update],
+      first_name_kana: [:create, :retrieve, :update], # Japan only
+      first_name_kanji: [:create, :retrieve, :update], # Japan only
+      gender: [:create, :retrieve, :update], # "male" or "female"
+      last_name: [:create, :retrieve, :update],
+      last_name_kana: [:create, :retrieve, :update], # Japan only
+      last_name_kanji: [:create, :retrieve, :update], # Japan only
+      maiden_name: [:create, :retrieve, :update],
+      personal_address: @address_map,
+      personal_address_kana: @address_kana_kanji_map, # Japan only
+      personal_address_kanji: @address_kana_kanji_map, # Japan only
+      personal_id_number: [:create, :update],
+      personal_id_number_provided: [:retrieve],
+      phone_number: [:create, :retrieve, :update],
+      ssn_last_4: [:create, :update], # US only
+      ssn_last_4_provided: [:retrieve],
+      type: [:create, :update, :retrieve], # "individual" or "company"
+      verification: %{
+        details: [:retrieve],
+        details_code: [:retrieve],
+        document: [:create, :retrieve, :update],
+        status: [:retrieve],
+      }
+    },
+    managed: [:create, :retrieve],
+    metadata: [:create, :retrieve, :update],
+    object: [:retrieve],
+    product_description: [:create, :retrieve, :update],
+    statement_descriptor: [:create, :retrieve, :update],
+    support_email: [:create, :retrieve, :update],
+    support_phone: [:create, :retrieve, :update],
+    support_url: [:create, :retrieve, :update],
+    timezone: [:retrieve],
+    tos_acceptance: %{
+      date: [:create, :retrieve, :update],
+      ip: [:create, :retrieve, :update],
+      user_agent: [:create, :retrieve, :update]
+    },
+    transfer_schedule: %{
+      delay_days: [:create, :retrieve, :update],
+      interval: [:create, :retrieve, :update],
+      monthly_anchor: [:create, :retrieve, :update],
+      weekly_anchor: [:create, :retrieve, :update]
+    },
+    transfer_statement_descriptor: [:create, :retrieve, :update],
+    verification: %{
+      disabled_reason: [:retrieve],
+      due_by: [:retrieve],
+      fields_needed: [:retrieve]
+    }
+  }
+
+  @doc """
+  Schema map indicating when a particular argument can be created on, retrieved
+  from, or updated on the Stripe API.
+  """
+  @spec schema :: Keyword.t
+  def schema, do: @schema
+
+  @nullable_keys [
+    :metadata, :transfer_statement_descriptor
   ]
 
   @doc """
@@ -50,9 +158,9 @@ defmodule Stripe.Account do
   @doc """
   Create an account.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def create(account, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, account, @valid_create_keys, __MODULE__, opts)
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(changes, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
   end
 
   @doc """
@@ -74,7 +182,7 @@ defmodule Stripe.Account do
   def retrieve(id, opts \\ []), do: do_retrieve(@plural_endpoint <> "/" <> id, opts)
 
   @spec do_retrieve(String.t, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  defp do_retrieve(endpoint, opts \\ []) do
+  defp do_retrieve(endpoint, opts) do
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 
@@ -86,6 +194,6 @@ defmodule Stripe.Account do
   @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
   end
 end

--- a/lib/stripe/bank_account.ex
+++ b/lib/stripe/bank_account.ex
@@ -26,17 +26,27 @@ defmodule Stripe.BankAccount do
 
   @plural_endpoint "bank_accounts"
 
-  @valid_create_keys [
-    :source, :object, :account_number, :country, :currency,
-    :account_holder_name, :account_holder_type, :routing_number,
-    :default_for_currency, :metadata
-  ]
+  @schema %{
+    account: [:retrieve],
+    account_number: :string,
+    account_holder_name: [:retrieve, :update],
+    account_holder_type: [:retrieve, :update],
+    bank_name: [:retrieve],
+    country: [:retrieve],
+    currency: [:retrieve],
+    default_for_currency: [:create, :retrieve],
+    external_account: [:create],
+    fingerprint: [:retrieve],
+    id: [:retrieve],
+    last4: [:retrieve],
+    metadata: [:create, :retrieve, :update],
+    object: [:retrieve],
+    routing_number: [:retrieve],
+    source: [:create],
+    status: [:retrieve]
+  }
 
-  @valid_update_keys [
-    :source, :object, :account_number, :country, :currency,
-    :account_holder_name, :account_holder_type, :routing_number,
-    :default_for_currency, :metadata
-  ]
+  @nullable_keys []
 
   @doc """
   Returns a map of relationship keys and their Struct name.
@@ -49,9 +59,9 @@ defmodule Stripe.BankAccount do
   @doc """
   Create a bank account.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def create(bank_account, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, bank_account, @valid_create_keys, __MODULE__, opts)
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(changes, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
   end
 
   @doc """
@@ -71,7 +81,7 @@ defmodule Stripe.BankAccount do
   @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -46,10 +46,40 @@ defmodule Stripe.Card do
 
   @relationships %{}
 
-  @valid_update_keys [
-    :address_city, :address_country, :address_line1, :address_line2,
-    :address_state, :address_zip, :exp_month, :exp_year, :metadata, :name
-  ]
+  @schema %{
+    account: [:retrieve],
+    address_city: [:retrieve, :update],
+    address_country: [:retrieve, :update],
+    address_line1: [:retrieve, :update],
+    address_line1_check: [:retrieve],
+    address_line2: [:retrieve, :update],
+    address_state: [:retrieve, :update],
+    address_zip: [:retrieve, :update],
+    address_zip_check: [:retrieve],
+    brand: [:retrieve, :update],
+    country: [:retrieve, :update],
+    currency: [:retrieve, :update],
+    customer: [:retrieve, :update],
+    cvc_check: [:retrieve, :update],
+    default_for_currency: [:create, :retrieve, :update],
+    dynamic_last4: [:retrieve],
+    exp_month: [:retrieve, :update],
+    exp_year: [:retrieve, :update],
+    external_account: [:create],
+    fingerprint: [:retrieve],
+    funding: [:retrieve],
+    id: [:retrieve],
+    last4: [:retrieve],
+    metadata: [:create, :retrieve, :update],
+    name: [:retrieve, :update],
+    object: [:retrieve],
+    recipient: [:retrieve],
+    source: [:create],
+    three_d_secure: [:retrieve],
+    tokenization_method: [:retrieve]
+  }
+
+  @nullable_keys []
 
   @doc """
   Returns a map of relationship keys and their Struct name.
@@ -115,7 +145,7 @@ defmodule Stripe.Card do
   @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(owner_type, owner_id, card_id, changes, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/changeset.ex
+++ b/lib/stripe/changeset.ex
@@ -1,0 +1,47 @@
+defmodule Stripe.Changeset do
+  alias Stripe.Util
+
+  @doc """
+  Takes changes as a map with atom or string keys, a nested schema map,
+  and an optional list of keys that can be unset.
+
+  Returns a whitelisted map that can be used to send to Stripe.
+  """
+  @spec cast(map, map, atom, list) :: map
+  def cast(changes, schema, operation, nullable_keys \\ []) do
+    keys = Map.keys(schema)
+    changes = Util.atomize_keys(changes)
+
+    Enum.reduce(keys, %{}, fn key, acc ->
+      schema_value = schema[key]
+      change = Map.get(changes, key)
+      acc |> apply_changes(key, change, operation, schema_value, nullable_keys)
+    end)
+  end
+
+  defp apply_changes(acc, key, change, op, schema_value, _) when is_map(change) and not is_list(schema_value) do
+    Map.put(acc, key, cast(change, schema_value, op))
+  end
+  defp apply_changes(acc, key, change, op, schema_value, nullable_keys) do
+    check_operation(acc, key, change, op, schema_value, nullable_keys)
+  end
+
+  defp check_operation(acc, key, change, op, ops, nullable_keys) do
+    case Enum.member?(ops, op) do
+      true  -> attempt_change(acc, key, change, nullable_keys)
+      false -> acc
+    end
+  end
+
+  defp attempt_change(acc, key, nil = change, nullable_keys) do
+    case Enum.member?(nullable_keys, key) do
+      true  -> put_change(acc, key, change)
+      false -> acc
+    end
+  end
+  defp attempt_change(acc, key, change, _nullable_keys), do: put_change(acc, key, change)
+
+  defp put_change(acc, key, change) do
+    Map.put(acc, key, change)
+  end
+end

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -28,14 +28,42 @@ defmodule Stripe.Customer do
 
   @plural_endpoint "customers"
 
-  @valid_create_keys [
-    :account_balance, :business_vat_id, :coupon, :description, :email,
-    :metadata, :plan, :quantity, :tax_percent, :trial_end, :source
-  ]
+  @address_map %{
+    city: [:create, :retrieve, :update], #required
+    country: [:create, :retrieve, :update],
+    line1: [:create, :retrieve, :update],
+    line2: [:create, :retrieve, :update],
+    postal_code: [:create, :retrieve, :update],
+    state: [:create, :retrieve, :update]
+  }
 
-  @valid_update_keys [
-    :account_balance, :business_vat_id, :coupon, :default_source, :description,
-    :email, :metadata, :source
+  @schema %{
+    account_balance: [:retrieve, :update],
+    business_vat_id: [:create, :retrieve, :update],
+    created: [:retrieve],
+    coupon: [:create, :retrieve, :update],
+    currency: [:retrieve],
+    default_source: [:retrieve, :update],
+    delinquent: [:retrieve],
+    description: [:create, :retrieve, :update],
+    discount: [:retrieve],
+    email: [:create, :retrieve, :update],
+    livemode: [:retrieve],
+    metadata: [:create, :retrieve, :update],
+    plan: [:create, :update],
+    quantity: [:create, :update],
+    shipping: %{
+      address: @address_map
+    },
+    source: [:create, :retrieve, :update],
+    sources: [:retrieve],
+    subscriptiones: [:retrieve],
+    tax_percent: [:create],
+    trial_end: [:create]
+  }
+
+  @nullable_keys [
+    :business_vat_id, :description, :email, :metadata
   ]
 
   @doc """
@@ -49,9 +77,9 @@ defmodule Stripe.Customer do
   @doc """
   Create a customer.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def create(customer, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, customer, @valid_create_keys, __MODULE__, opts)
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(changes, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
   end
 
   @doc """
@@ -71,7 +99,7 @@ defmodule Stripe.Customer do
   @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -27,13 +27,23 @@ defmodule Stripe.Plan do
 
   @plural_endpoint "plans"
 
-  @valid_create_keys [
-    :id, :amount, :currency, :interval, :interval_count, :metadata, :name,
-    :statement_descriptor, :trial_period_days
-  ]
+  @schema %{
+    amount: [:create, :retrieve],
+    created: [:retrieve],
+    currency: [:create, :retrieve],
+    id: [:create, :retrieve],
+    interval: [:create, :retrieve],
+    interval_count: [:create, :retrieve],
+    livemode: [:retrieve],
+    metadata: [:create, :retrieve, :update],
+    name: [:create, :retrieve, :update],
+    object: [:retrieve],
+    statement_descriptor: [:create, :retrieve, :update],
+    trial_period_days: [:create, :retrieve, :update]
+  }
 
-  @valid_update_keys [
-    :metadata, :name, :statement_descriptor, :trial_period_days
+  @nullable_keys [
+    :metadata, :statement_descriptor
   ]
 
   @doc """
@@ -47,9 +57,9 @@ defmodule Stripe.Plan do
   @doc """
   Create a plan.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def create(plan, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, plan, @valid_create_keys, __MODULE__, opts)
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(changes, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
   end
 
   @doc """
@@ -69,7 +79,7 @@ defmodule Stripe.Plan do
   @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -1,13 +1,12 @@
 defmodule Stripe.Request do
-  alias Stripe.Util
+  alias Stripe.Changeset
   alias Stripe.Converter
 
-  @spec create(String.t, struct, map, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def create(endpoint, struct, valid_keys, module, opts) do
+  @spec create(String.t, map, map, module, Keyword.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
+  def create(endpoint, changes, schema, module, opts) do
     body =
-      struct
-      |> Map.take(valid_keys)
-      |> Util.drop_nil_keys()
+      changes
+      |> Changeset.cast(schema, :create)
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
       {:ok, result} -> {:ok, Converter.stripe_map_to_struct(module, result)}
@@ -40,13 +39,11 @@ defmodule Stripe.Request do
     end
   end
 
-  @spec update(String.t, map, map, struct, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def update(endpoint, changes, valid_keys, module, opts) do
+  @spec update(String.t, map, map, struct, list, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def update(endpoint, changes, schema, nullable_keys, module, opts) do
     body =
       changes
-      |> Util.map_keys_to_atoms()
-      |> Map.take(valid_keys)
-      |> Util.drop_nil_keys()
+      |> Changeset.cast(schema, :update, nullable_keys)
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
       {:ok, result} -> {:ok, Converter.stripe_map_to_struct(module, result)}

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -24,6 +24,10 @@ defmodule Stripe.Subscription do
   ]
 
   @relationships %{
+    created: DateTime,
+    current_period_end: DateTime,
+    current_period_start: DateTime,
+    ended_at: DateTime,
     plan: Stripe.Plan,
     start: DateTime,
     trial_end: DateTime,
@@ -32,14 +36,35 @@ defmodule Stripe.Subscription do
 
   @plural_endpoint "subscriptions"
 
-  @valid_create_keys [
-    :application_fee_percent, :coupon, :customer, :metadata, :plan, :quantity,
-    :source, :tax_percent, :trial_end
-  ]
+  @schema %{
+    application_fee_percent: [:create, :retrieve, :update],
+    cancel_at_period_end: [:retrieve],
+    canceled_at: [:retrieve],
+    coupon: [:create, :update],
+    created: [:retrieve],
+    current_period_end: [:retrieve],
+    current_period_start: [:retrieve],
+    customer: [:create, :retrieve],
+    discount: [:retrieve],
+    ended_at: [:retrieve],
+    id: [:retrieve],
+    livemode: [:retrieve],
+    metadata: [:create, :retrieve, :update],
+    object: [:retrieve],
+    plan: [:create, :retrieve, :update],
+    prorate: [:create],
+    quantity: [:create, :retrieve, :update],
+    source: [:create, :update],
+    start: [:retrieve],
+    status: [:retrieve],
+    tax_percent: [:create, :retrieve, :update],
+    trial_end: [:create, :retrieve, :update],
+    trial_period_days: [:create],
+    trial_start: [:create, :retrieve]
+  }
 
-  @valid_update_keys [
-    :application_fee_percent, :coupon, :metadata, :plan, :prorate,
-    :proration_date, :quantity, :source, :tax_percent, :trial_end
+  @nullable_keys [
+    :metadata
   ]
 
   @doc """
@@ -53,9 +78,9 @@ defmodule Stripe.Subscription do
   @doc """
   Create a subscription.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def create(subscription, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, subscription, @valid_create_keys, __MODULE__, opts)
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(changes, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
   end
 
   @doc """
@@ -75,7 +100,7 @@ defmodule Stripe.Subscription do
   @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/token.ex
+++ b/lib/stripe/token.ex
@@ -25,9 +25,21 @@ defmodule Stripe.Token do
 
   @plural_endpoint "tokens"
 
-  @valid_create_connect_keys [
-    :card, :customer
-  ]
+  @schema %{
+    bank_account: [:create, :retrieve],
+    card: [:create, :retrieve],
+    client_ip: [:retrieve],
+    created: [:retrieve],
+    customer: [:create],
+    id: [:retrieve],
+    livemode: [:retrieve],
+    object: [:retrieve],
+    pii: %{
+      personal_id_number: [:create]
+    },
+    type: [:retrieve],
+    used: [:retrieve]
+  }
 
   @doc """
   Returns a map of relationship keys and their Struct name.
@@ -38,7 +50,8 @@ defmodule Stripe.Token do
   def relationships, do: @relationships
 
   @doc """
-  Create a token for a Connect customer with a card belonging to that customer.
+  Create a token for a Connect customer with a card belonging to the
+  platform customer.
 
   You must pass in the account number for the Stripe Connect account
   in `opts`.
@@ -49,7 +62,21 @@ defmodule Stripe.Token do
       card: customer_card_id,
       customer: customer_id
     }
-    Stripe.Request.create(@plural_endpoint, body, @valid_create_connect_keys, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, body, @schema, __MODULE__, opts)
+  end
+
+  @doc """
+  Create a token for a Connect customer using the default card.
+
+  You must pass in the account number for the Stripe Connect account
+  in `opts`.
+  """
+  @spec create_with_default_card(String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create_with_default_card(customer_id, opts \\ []) do
+    body = %{
+      customer: customer_id
+    }
+    Stripe.Request.create(@plural_endpoint, body, @schema, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -1,16 +1,6 @@
 defmodule Stripe.Util do
   @moduledoc false
 
-  alias Stripe.Convert
-
-  def drop_nil_keys(map) do
-    Enum.reject(map, fn
-      {_, nil} -> true
-      _ -> false
-    end)
-    |> Enum.into(%{})
-  end
-
   @spec get_date(map, atom | String.t) :: DateTime.t | nil
   def get_date(m, k) do
     case Map.get(m, k) do
@@ -76,4 +66,16 @@ defmodule Stripe.Util do
   def string_map_to_atoms(string_key_map) do
     for {key, val} <- string_key_map, into: %{}, do: {String.to_atom(key), val}
   end
+
+  def atomize_keys(map = %{}) do
+    map
+    |> Enum.map(fn {k, v} -> {atomize_key(k), atomize_keys(v)} end)
+    |> Enum.into(%{})
+  end
+  def atomize_keys([head | rest]), do: [atomize_keys(head) | atomize_keys(rest)]
+  # Default
+  def atomize_keys(not_a_map), do: not_a_map
+
+  def atomize_key(k) when is_binary(k), do: String.to_atom(k)
+  def atomize_key(k), do: k
 end

--- a/test/stripe/changeset_test.exs
+++ b/test/stripe/changeset_test.exs
@@ -1,0 +1,62 @@
+defmodule Stripe.ChangesetTest do
+  use ExUnit.Case
+
+  alias Stripe.Changeset
+
+  @json_params %{
+    "email" => nil,
+    "external_account" => "btok_123",
+    "legal_entity" => %{
+      "ssn_last_4" => "1234",
+      "ssn_last_4_provided" => true
+    }
+  }
+
+  @map_params %{
+    email: nil,
+    external_account: "btok_123",
+    legal_entity: %{
+      ssn_last_4: "1234",
+      ssn_last_4_provided: true
+    }
+  }
+
+  @schema %{
+    email: [:create, :retrieve, :update],
+    external_account: [:create, :retrieve, :update],
+    legal_entity: %{
+      ssn_last_4: [:create, :update]
+    },
+    managed: [:create, :retrieve]
+  }
+
+  @expected_map %{
+    external_account: "btok_123",
+    legal_entity: %{
+      ssn_last_4: "1234"
+    }
+  }
+
+  test "works for JSON" do
+    result = Changeset.cast(@json_params, @schema, :create)
+    assert result == @expected_map
+  end
+
+  test "works for maps" do
+    result = Changeset.cast(@map_params, @schema, :create)
+    assert result == @expected_map
+  end
+
+  test "works with nullable keys" do
+    nullable_keys = [:email]
+    result = Changeset.cast(@map_params, @schema, :create, nullable_keys)
+    expected_map = @expected_map |> Map.merge(%{email: nil})
+    assert result == expected_map
+  end
+
+  test "removes attributes that are not expected for the operation" do
+    map_params = @map_params |> Map.merge(%{managed: true})
+    result = Changeset.cast(map_params, @schema, :update)
+    assert result == @expected_map
+  end
+end


### PR DESCRIPTION
This adds the concept of a changeset for doing updates.

We should probably go back through and allow something like it for creates, as well. Would also like to remove the specification of value types since value types are (unfortunately) mutable in many cases on Stripe's API (token vs hash, string instead of Unix timestamp, etc).