### PR TITLE
Add dialyzer, fix several issues, including a few bugs with bad function calls.

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -156,7 +156,8 @@ defmodule Stripe do
   end
 
   @type method :: :get | :post | :put | :delete | :patch
-  @type headers :: %{String.t => String.t}
+  @type headers :: %{String.t => String.t} | %{}
+  @type body :: {:multipart, list} | map
   @typep http_success :: {:ok, integer, [{String.t, String.t}], String.t}
   @typep http_failure :: {:error, term}
 
@@ -185,7 +186,7 @@ defmodule Stripe do
   to comply with the expectations of the BEAM application standard.
   It is not given any children to supervise.
   """
-  @spec start(Application.start_type, any) :: :ok
+  @spec start(Application.start_type, any) :: {:error, any} | {:ok, pid} | {:ok, pid, any}
   def start(_start_type, _args) do
     import Supervisor.Spec, warn: false
 
@@ -329,7 +330,7 @@ defmodule Stripe do
 
   @doc """
   """
-  @spec request_file_upload(method, String.t, map, headers, list) :: {:ok, map} | {:error, api_error_struct}
+  @spec request_file_upload(method, String.t, body, headers, list) :: {:ok, map} | {:error, api_error_struct}
   def request_file_upload(method, endpoint, body, headers, opts) do
     {connect_account_id, opts} = Keyword.pop(opts, :connect_account)
     {api_key, opts} = Keyword.pop(opts, :api_key)

--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -141,7 +141,7 @@ defmodule Stripe.Account do
   Schema map indicating when a particular argument can be created on, retrieved
   from, or updated on the Stripe API.
   """
-  @spec schema :: Keyword.t
+  @spec schema :: map
   def schema, do: @schema
 
   @nullable_keys [
@@ -153,7 +153,7 @@ defmodule Stripe.Account do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   @doc """
@@ -192,7 +192,7 @@ defmodule Stripe.Account do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -86,7 +86,7 @@ defmodule Stripe.Card do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   defp endpoint_for_owner(owner_type, owner_id) do
@@ -145,7 +145,7 @@ defmodule Stripe.Card do
   @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(owner_type, owner_id, card_id, changes, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
-    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -44,7 +44,7 @@ defmodule Stripe.Connect.OAuth do
     Relationships must be specified for the relationship to
     be returned as a struct.
     """
-    @spec relationships :: Keyword.t
+    @spec relationships :: map
     def relationships, do: @relationships
   end
 

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -97,7 +97,7 @@ defmodule Stripe.Customer do
   @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -69,7 +69,7 @@ defmodule Stripe.Customer do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   @doc """
@@ -94,7 +94,7 @@ defmodule Stripe.Customer do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)

--- a/lib/stripe/event.ex
+++ b/lib/stripe/event.ex
@@ -27,7 +27,7 @@ defmodule Stripe.Event do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   @doc """

--- a/lib/stripe/external_account.ex
+++ b/lib/stripe/external_account.ex
@@ -53,7 +53,7 @@ defmodule Stripe.ExternalAccount do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   defp endpoint(managed_account_id) do
@@ -83,10 +83,10 @@ defmodule Stripe.ExternalAccount do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts = [connect_account: managed_account_id]) do
     endpoint = endpoint(managed_account_id) <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/file_upload.ex
+++ b/lib/stripe/file_upload.ex
@@ -25,7 +25,7 @@ defmodule Stripe.FileUpload do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   @doc """

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -49,7 +49,7 @@ defmodule Stripe.Plan do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   @doc """
@@ -74,10 +74,10 @@ defmodule Stripe.Plan do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -39,7 +39,7 @@ defmodule Stripe.Request do
     end
   end
 
-  @spec update(String.t, map, map, struct, list, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  @spec update(String.t, map, map, list, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def update(endpoint, changes, schema, nullable_keys, module, opts) do
     body =
       changes

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -32,7 +32,7 @@ defmodule Stripe.Subscription do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   @plural_endpoint "subscriptions"
@@ -90,10 +90,10 @@ defmodule Stripe.Subscription do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/token.ex
+++ b/lib/stripe/token.ex
@@ -45,7 +45,7 @@ defmodule Stripe.Token do
   Relationships must be specified for the relationship to
   be returned as a struct.
   """
-  @spec relationships :: Keyword.t
+  @spec relationships :: map
   def relationships, do: @relationships
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -47,6 +47,7 @@ defmodule Stripe.Mixfile do
   defp deps do
     [
       {:bypass, "~> 0.5", only: :test},
+      {:dialyxir, "~> 0.4", only: [:dev], runtime: false},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.14", only: :dev},
       {:excoveralls, "~> 0.5", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
+  "dialyxir": {:hex, :dialyxir, "0.4.1", "236056d6acd25f740f336756c0f3b5dd6e2f0156074bc15f3b779aeee15390c8", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "exactor": {:hex, :exactor, "2.2.1", "89bc6798f7ed5b5a090f8e4a0b6997478a3266e831d2ff31677ac764ffa75973", [:mix], []},


### PR DESCRIPTION
Closes #182

Discovered while figuring out https://github.com/code-corps/code-corps-api/issues/610

`Stripe.Customer.update` was calling `Stripe.Request.update` with an incorrect argument order.

Since this is about building a request, without some sort of dependency injection implemented, it would be difficult to write a regression test. 

Additionally, the spec for `Stripe.Request.update` seems to be wrong. `list` should be before `struct` and struct itself should be `module` -

* `%Stripe.Customer{}` is a `struct`
* `Stripe.Customer` is a `module`

While we're at it, do we have a system setup to actually make use of these specs, or is that still on the todo list?




