### PR TITLE
Improve URI module efficiency

### DIFF
--- a/lib/stripe/uri.ex
+++ b/lib/stripe/uri.ex
@@ -10,13 +10,13 @@ defmodule Stripe.URI do
   end
 
   @doc """
-  Takes a map and turns it into proper query values.
+  Takes a keyword/map and turns it into proper query values.
 
   ## Parameters
-    - list: a map of query parameters and values, which may themselves be maps
+    - list: a keyword/map of query parameters and values, which may also be enum
 
   ## Examples
-  iex> Stripe.URI.encode_query(%{"card": %{"number": 1234, "exp_year": 2014}})
+  iex> Stripe.URI.encode_query(%{card: %{number: 1234, exp_year: 2014}})
   "card[exp_year]=2014&card[number]=1234"
   """
   @spec encode_query(Enum.t) :: String.t
@@ -26,7 +26,7 @@ defmodule Stripe.URI do
 
   defp pair({key, values})
   when is_list(values) or is_map(values) do
-    pair(to_string(key), [], values)
+    pair(key, [], values)
   end
 
   defp pair({key, value}) do

--- a/test/stripe/uri_test.exs
+++ b/test/stripe/uri_test.exs
@@ -1,5 +1,6 @@
 defmodule Stripe.UriTest do
   use ExUnit.Case
+  doctest Stripe.URI
 
   test "keyword list encoding" do
     assert Stripe.URI.encode_query([a: 1]) == "a=1"
@@ -34,5 +35,9 @@ defmodule Stripe.UriTest do
     assert Stripe.URI.encode_query(%{a: "poll:146%"}) == "a=poll%3A146%25"
     assert Stripe.URI.encode_query(%{a: "/\n+/ゆ"}) == "a=%2F%0A%2B%2F%E3%82%86"
     assert Stripe.URI.encode_query(%{a: "/\n+/ゆ"}) == "a=%2F%0A%2B%2F%E3%82%86"
+  end
+
+  test "nested map encoding" do
+    assert Stripe.URI.encode_query(%{a: %{b: 1}}) == "a[b]=1"
   end
 end


### PR DESCRIPTION
The Stripe.URI module used a less-efficient method for building the HTTP query params string. Here, we switch to a more efficient list prepend and reverse pattern. Also, the recursive parser made use of Enumerable.impl_for/1 which is fairly heavyweight. By checking for maps or lists (which are assumed to be keyword lists) we can remove impl_for. I wish I could DRY up that check, but the small difference between the guard and non-guard syntax prevents it.

Addresses https://github.com/code-corps/stripity_stripe/issues/105