### PR TITLE
Pattern match on object keys for response sub-objects

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -25,8 +25,6 @@ defmodule Stripe.Account do
     :verification
   ]
 
-  @relationships %{}
-
   @singular_endpoint "account"
   @plural_endpoint "accounts"
 
@@ -147,14 +145,6 @@ defmodule Stripe.Account do
   @nullable_keys [
     :metadata, :transfer_statement_descriptor
   ]
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   @doc """
   Create an account.

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -44,8 +44,6 @@ defmodule Stripe.Card do
     :tokenization_method
   ]
 
-  @relationships %{}
-
   @schema %{
     account: [:retrieve],
     address_city: [:retrieve, :update],
@@ -80,14 +78,6 @@ defmodule Stripe.Card do
   }
 
   @nullable_keys []
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   defp endpoint_for_owner(owner_type, owner_id) do
     case owner_type do

--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -36,16 +36,6 @@ defmodule Stripe.Connect.OAuth do
       :access_token, :livemode, :refresh_token, :scope, :stripe_user_id,
       :stripe_publishable_key, :token_type
     ]
-
-    @relationships %{}
-
-    @doc """
-    Returns a map of relationship keys and their Struct name.
-    Relationships must be specified for the relationship to
-    be returned as a struct.
-    """
-    @spec relationships :: map
-    def relationships, do: @relationships
   end
 
   defmodule DeauthorizeResponse do

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -14,21 +14,10 @@ defmodule Stripe.Converter do
           fetch_value(response, key)
           |> convert_value()
 
-        value =
-          module.relationships
-          |> Map.get(key)
-          |> maybe_build_struct(value)
-
         Map.put(acc, key, value)
       end)
 
     struct(module, processed_map)
-  end
-
-  defp maybe_build_struct(nil, value), do: value
-  defp maybe_build_struct(_module, nil), do: nil
-  defp maybe_build_struct(module, value) when is_map(value) do
-    stripe_map_to_struct(module, value)
   end
 
   defp fetch_value(response, key) do
@@ -41,10 +30,20 @@ defmodule Stripe.Converter do
   defp convert_key(key) when is_atom(key), do: to_string(key)
   defp convert_key(key) when is_binary(key), do: String.to_atom(key)
 
+  # converts maps that are actually Stripe objects
+  defp convert_value(%{"object" => object_name} = value) when is_binary(object_name) do
+    object_name
+    |> Stripe.Util.object_name_to_module
+    |> stripe_map_to_struct(value)
+  end
+
+  # converts plain maps
   defp convert_value(value) when is_map(value) do
     Enum.reduce(value, %{}, fn({key, value}, acc) ->
       Map.put(acc, String.to_atom(key), convert_value(value))
     end)
   end
+
+  # converts anything else
   defp convert_value(value), do: value
 end

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -22,8 +22,6 @@ defmodule Stripe.Customer do
     :metadata
   ]
 
-  @relationships %{}
-
   @plural_endpoint "customers"
 
   @address_map %{
@@ -63,14 +61,6 @@ defmodule Stripe.Customer do
   @nullable_keys [
     :business_vat_id, :description, :email, :metadata
   ]
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   @doc """
   Create a customer.

--- a/lib/stripe/event.ex
+++ b/lib/stripe/event.ex
@@ -14,21 +14,11 @@ defmodule Stripe.Event do
   @type t :: %__MODULE__{}
 
   defstruct [
-    :id, :object, :api_version, :created, :livemode, :pending_webhooks,
+    :id, :object, :api_version, :created, :data, :livemode, :pending_webhooks,
     :request, :type, :user_id
   ]
 
-  @relationships %{}
-
   @plural_endpoint "events"
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   @doc """
   Retrieve an event.

--- a/lib/stripe/external_account.ex
+++ b/lib/stripe/external_account.ex
@@ -24,11 +24,9 @@ defmodule Stripe.ExternalAccount do
     :last4, :metadata, :routing_number, :status
   ]
 
-  @relationships %{}
-
   @schema %{
     account: [:retrieve],
-    account_number: :string,
+    account_number: [:retrieve],
     account_holder_name: [:retrieve, :update],
     account_holder_type: [:retrieve, :update],
     bank_name: [:retrieve],
@@ -47,14 +45,6 @@ defmodule Stripe.ExternalAccount do
   }
 
   @nullable_keys []
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   defp endpoint(managed_account_id) do
     "accounts/#{managed_account_id}/external_accounts"

--- a/lib/stripe/file_upload.ex
+++ b/lib/stripe/file_upload.ex
@@ -16,17 +16,7 @@ defmodule Stripe.FileUpload do
     :id, :object, :created, :purpose, :size, :type, :metadata
   ]
 
-  @relationships %{}
-
   @plural_endpoint "files"
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   @doc """
   Create a file according to Stripe's file_upload rules.

--- a/lib/stripe/invoice.ex
+++ b/lib/stripe/invoice.ex
@@ -27,8 +27,6 @@ defmodule Stripe.Invoice do
     :webhooks_delivered_at
   ]
 
-  @relationships %{}
-
   @plural_endpoint "invoices"
 
   @schema %{
@@ -65,14 +63,6 @@ defmodule Stripe.Invoice do
   }
 
   @nullable_keys []
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: Keyword.t
-  def relationships, do: @relationships
 
   @doc """
   Create an invoice.

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -21,8 +21,6 @@ defmodule Stripe.Plan do
     :livemode, :metadata, :name, :statement_descriptor, :trial_period_days
   ]
 
-  @relationships %{}
-
   @plural_endpoint "plans"
 
   @schema %{
@@ -43,14 +41,6 @@ defmodule Stripe.Plan do
   @nullable_keys [
     :metadata, :statement_descriptor
   ]
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   @doc """
   Create a plan.

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -23,18 +23,6 @@ defmodule Stripe.Subscription do
     :start, :status, :tax_percent, :trial_end, :trial_start
   ]
 
-  @relationships %{
-    plan: Stripe.Plan
-  }
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
-
   @plural_endpoint "subscriptions"
 
   @schema %{

--- a/lib/stripe/token.ex
+++ b/lib/stripe/token.ex
@@ -18,10 +18,6 @@ defmodule Stripe.Token do
     :id, :card, :client_ip, :created, :livemode, :type, :used
   ]
 
-  @relationships %{
-    card: Stripe.Card
-  }
-
   @plural_endpoint "tokens"
 
   @schema %{
@@ -39,14 +35,6 @@ defmodule Stripe.Token do
     type: [:retrieve],
     used: [:retrieve]
   }
-
-  @doc """
-  Returns a map of relationship keys and their Struct name.
-  Relationships must be specified for the relationship to
-  be returned as a struct.
-  """
-  @spec relationships :: map
-  def relationships, do: @relationships
 
   @doc """
   Create a token for a Connect customer with a card belonging to the

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -58,4 +58,16 @@ defmodule Stripe.Util do
 
   def atomize_key(k) when is_binary(k), do: String.to_atom(k)
   def atomize_key(k), do: k
+
+  @spec object_name_to_module(String.t) :: module
+  def object_name_to_module("bank_account"), do: Stripe.ExternalAccount
+  def object_name_to_module(object_name) do
+    module_name =
+      object_name
+      |> String.split("_")
+      |> Enum.map(&String.capitalize/1)
+      |> Enum.join("")
+
+    Module.concat("Stripe", module_name)
+  end
 end

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -6,27 +6,13 @@ defmodule Stripe.ConverterTest do
 
   defmodule Person do
     defstruct [:email, :first_name, :last_name, :legal_entity, :metadata]
-    def relationships, do: %{}
-  end
-
-  defmodule PersonWithMissingRelationship do
-    defstruct [:card]
-    def relationships, do: %{card: ConverterTest.CreditCard}
   end
 
   defmodule AuthToken do
     defstruct [:id, :card, :client_ip, :created, :livemode, :type, :used]
-    def relationships, do: %{
-      card: ConverterTest.CreditCard
-    }
   end
 
-  defmodule CreditCard do
-    defstruct [:brand, :country, :exp_month]
-    def relationships, do: %{}
-  end
-
-  test "converts a Stripe response into a struct" do
+  test "converts a response into a struct" do
     expected_result = %Stripe.ConverterTest.Person{
       first_name: "Leslie",
       last_name: "Knope",
@@ -73,11 +59,11 @@ defmodule Stripe.ConverterTest do
     }
   end
 
-  test "converts relationship keys into a struct" do
+  test "converts a stripe card sub-object into a struct" do
     expected_result = %Stripe.ConverterTest.AuthToken{
       id: "token_id",
       used: false,
-      card: %Stripe.ConverterTest.CreditCard{
+      card: %Stripe.Card{
         brand: "Visa",
         country: "US",
         exp_month: 8
@@ -86,17 +72,18 @@ defmodule Stripe.ConverterTest do
     }
 
     result = Converter.stripe_map_to_struct(
-      ConverterTest.AuthToken, json_response_with_relationship
+      ConverterTest.AuthToken, json_response_with_card_subobject
     )
     assert result == expected_result
   end
 
-  defp json_response_with_relationship do
+  defp json_response_with_card_subobject do
     %{
       "id" => "token_id",
       "used" => false,
       "created" => 1462905445,
       "card" => %{
+        "object" => "card",
         "brand" => "Visa",
         "country" => "US",
         "exp_month" => 8,
@@ -104,12 +91,90 @@ defmodule Stripe.ConverterTest do
     }
   end
 
-  test "returns nil when a specified relationship is not in the Stripe response" do
-    expected_result = %Stripe.ConverterTest.PersonWithMissingRelationship{
-      card: nil
+  @event_response %{
+    "id" => "evt_19YEx1BKl1F6IRFfb1cFLHzZ",
+    "object" => "event",
+    "api_version" => "2016-07-06",
+    "created" => 1483537031,
+    "data" => %{
+      "object" => %{
+        "id" => "cus_9ryX7lUQ4Dcpf7",
+        "object" => "customer",
+        "account_balance" => 0,
+        "created" => 1483535628,
+        "currency" => nil,
+        "default_source" => nil,
+        "delinquent" => false,
+        "description" => nil,
+        "discount" => nil,
+        "email" => "test2@mail.com",
+        "livemode" => false,
+        "metadata" => %{},
+        "shipping" => nil,
+        "sources" => %{
+          "object" => "list",
+          "data" => [],
+          "has_more" => false,
+          "total_count" => 0,
+          "url" => "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources"
+        },
+        "subscriptions" => %{
+          "object" => "list",
+          "data" => [],
+          "has_more" => false,
+          "total_count" => 0,
+          "url" => "/v1/customers/cus_9ryX7lUQ4Dcpf7/subscriptions"
+        }
+      },
+      "previous_attributes" => %{
+        "description" => "testcustomer",
+        "email" => "test@mail.com",
+        "metadata" => %{
+          "test" => "key"
+        }
+      }
+    },
+    "livemode" => false,
+    "pending_webhooks" => 0,
+    "request" => "req_9ryusbEBenV0BX",
+    "type" => "customer.updated"
+  }
+
+  test "converts an event response properly" do
+    expected_result = %Stripe.Event{
+      api_version: "2016-07-06",
+      created: 1483537031,
+      data: %{
+        object: %Stripe.Customer{
+          account_balance: 0,
+          business_vat_id: nil,
+          created: 1483535628,
+          currency: nil,
+          default_source: nil,
+          delinquent: false,
+          description: nil,
+          email: "test2@mail.com",
+          id: "cus_9ryX7lUQ4Dcpf7",
+          livemode: false,
+          metadata: %{}
+        },
+        previous_attributes: %{
+          description: "testcustomer",
+          email: "test@mail.com",
+          metadata: %{test: "key"}
+        }
+      },
+      id: "evt_19YEx1BKl1F6IRFfb1cFLHzZ",
+      livemode: false,
+      object: "event",
+      pending_webhooks: 0,
+      request: "req_9ryusbEBenV0BX",
+      type: "customer.updated",
+      user_id: nil
     }
 
-    result = Converter.stripe_map_to_struct(ConverterTest.PersonWithMissingRelationship, json_response)
+    result = Converter.stripe_map_to_struct(Stripe.Event, @event_response)
+
     assert result == expected_result
   end
 end

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -1,4 +1,21 @@
 defmodule Stripe.UtilTest do
   use ExUnit.Case
 
+  import Stripe.Util
+
+  describe "object_name_to_module/1" do
+  	test "converts all object names to their proper modules" do
+      assert object_name_to_module("account") == Stripe.Account
+      assert object_name_to_module("bank_account") == Stripe.ExternalAccount
+      assert object_name_to_module("card") == Stripe.Card
+      assert object_name_to_module("customer") == Stripe.Customer
+      assert object_name_to_module("event") == Stripe.Event
+      assert object_name_to_module("external_account") == Stripe.ExternalAccount
+      assert object_name_to_module("file_upload") == Stripe.FileUpload
+      assert object_name_to_module("invoice") == Stripe.Invoice
+      assert object_name_to_module("plan") == Stripe.Plan
+      assert object_name_to_module("subscription") == Stripe.Subscription
+      assert object_name_to_module("token") == Stripe.Token
+    end
+  end
 end


### PR DESCRIPTION
This modifies the converter module to pattern match on object keys for sub-hashes, if these are present. It allows us to properly serialize stripe objects such as events, due to these having dynamic relationships (an event can hold any other non-specific stripe object).

It also completely removes the need for the relationships attribute/method on all our modules.

Closes #187 

This change puts us in a position where we could similarly do the same for the base object itself, since all Stripe objects have the "object" key. It would remove the need to pass in the module into our `Converter.stripe_map_to_struct` method. It potentially even could allow us to remove the need to pass in the module into our `Request.<action>` methods.

Another option this opens is the ability to properly serialize lists. I will create issues for both of these.