### PR TITLE
Basic list implementation

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -30,9 +30,7 @@ defmodule Stripe.Converter do
   defp convert_key(key) when is_atom(key), do: to_string(key)
   defp convert_key(key) when is_binary(key), do: String.to_atom(key)
 
-  @supported_objects ~w(account bank_account card customer event external_account file_upload invoice plan subscription token)
-
-  defp convert_value(%{"object" => "list"} = value), do: convert_map(value)
+  @supported_objects ~w(account bank_account card customer event external_account file_upload invoice list plan subscription token)
 
   # converts maps that are actually Stripe objects
   defp convert_value(%{"object" => object_name} = value) when is_binary(object_name) do
@@ -44,6 +42,9 @@ defmodule Stripe.Converter do
 
   # converts plain maps
   defp convert_value(value) when is_map(value), do: convert_map(value)
+
+  # converts lists
+  defp convert_value(value) when is_list(value), do: convert_list(value)
 
   # converts anything else
   defp convert_value(value), do: value
@@ -58,5 +59,9 @@ defmodule Stripe.Converter do
     object_name
     |> Stripe.Util.object_name_to_module
     |> stripe_map_to_struct(value)
+  end
+
+  defp convert_list(list) do
+    list |> Enum.map(&convert_value/1)
   end
 end

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -18,8 +18,8 @@ defmodule Stripe.Customer do
 
   defstruct [
     :id, :account_balance, :business_vat_id, :created, :currency,
-    :default_source, :delinquent, :description, :email, :livemode,
-    :metadata
+    :default_source, :delinquent, :description, :discount, :email,
+    :livemode, :metadata, :shipping, :sources, :subscriptions
   ]
 
   @plural_endpoint "customers"
@@ -53,7 +53,7 @@ defmodule Stripe.Customer do
     },
     source: [:create, :retrieve, :update],
     sources: [:retrieve],
-    subscriptiones: [:retrieve],
+    subscriptions: [:retrieve],
     tax_percent: [:create],
     trial_end: [:create]
   }

--- a/lib/stripe/list.ex
+++ b/lib/stripe/list.ex
@@ -1,0 +1,19 @@
+defmodule Stripe.List do
+  @moduledoc """
+  Work with Stripe list objects.
+
+  A list is a general-purpose Stripe object which holds one or more
+  other Stripe objects in its "data" property.
+
+  In its current iteration it simply allows serializing into a properly
+  typed struct.
+
+  In future iterations, it should:
+  - Support multiple types of objects in its collection
+  - Support fetching the next set of objects (pagination)
+  """
+
+  @type t :: %__MODULE__{}
+
+  defstruct [:data, :has_more, :total_count, :url]
+end

--- a/test/fixtures/card_list.json
+++ b/test/fixtures/card_list.json
@@ -1,0 +1,58 @@
+{
+  "object": "list",
+  "url": "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources",
+  "has_more": false,
+  "total_count": 2,
+  "data": [
+    {
+      "id": "card_19YDiuBKl1F6IRFflldIp6Dc",
+      "object": "card",
+      "address_city": null,
+      "address_country": null,
+      "address_line1": null,
+      "address_line1_check": null,
+      "address_line2": null,
+      "address_state": null,
+      "address_zip": null,
+      "address_zip_check": null,
+      "brand": "Visa",
+      "country": "US",
+      "customer": "cus_9ryX7lUQ4Dcpf7",
+      "cvc_check": null,
+      "dynamic_last4": null,
+      "exp_month": 8,
+      "exp_year": 2018,
+      "funding": "credit",
+      "last4": "4242",
+      "metadata": {
+      },
+      "name": null,
+      "tokenization_method": null
+    },
+    {
+      "id": "card_abcdiuBKl1F6IRFflldIp6Dc",
+      "object": "card",
+      "address_city": null,
+      "address_country": null,
+      "address_line1": null,
+      "address_line1_check": null,
+      "address_line2": null,
+      "address_state": null,
+      "address_zip": null,
+      "address_zip_check": null,
+      "brand": "Visa",
+      "country": "US",
+      "customer": "cus_9ryX7lUQ4Dcpf7",
+      "cvc_check": null,
+      "dynamic_last4": null,
+      "exp_month": 12,
+      "exp_year": 2020,
+      "funding": "credit",
+      "last4": "4242",
+      "metadata": {
+      },
+      "name": null,
+      "tokenization_method": null
+    }
+  ]
+}

--- a/test/fixtures/customer.json
+++ b/test/fixtures/customer.json
@@ -1,0 +1,30 @@
+{
+  "id": "cus_9ryX7lUQ4Dcpf7",
+  "object": "customer",
+  "account_balance": 0,
+  "created": 1483535628,
+  "currency": "usd",
+  "default_source": null,
+  "delinquent": false,
+  "description": null,
+  "discount": null,
+  "email": "test2@mail.com",
+  "livemode": false,
+  "metadata": {
+  },
+  "shipping": null,
+  "sources": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources"
+  },
+  "subscriptions": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/customers/cus_9ryX7lUQ4Dcpf7/subscriptions"
+  }
+}

--- a/test/fixtures/event_with_customer.json
+++ b/test/fixtures/event_with_customer.json
@@ -1,0 +1,52 @@
+{
+  "id": "evt_19YEx1BKl1F6IRFfb1cFLHzZ",
+  "object": "event",
+  "api_version": "2016-07-06",
+  "created": 1483537031,
+  "data": {
+    "object": {
+      "id": "cus_9ryX7lUQ4Dcpf7",
+      "object": "customer",
+      "account_balance": 0,
+      "created": 1483535628,
+      "currency": null,
+      "default_source": null,
+      "delinquent": false,
+      "description": null,
+      "discount": null,
+      "email": "test2@mail.com",
+      "livemode": false,
+      "metadata": {
+      },
+      "shipping": null,
+      "sources": {
+        "object": "list",
+        "data": [
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources"
+      },
+      "subscriptions": {
+        "object": "list",
+        "data": [
+
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/customers/cus_9ryX7lUQ4Dcpf7/subscriptions"
+      }
+    },
+    "previous_attributes": {
+      "description": "testcustomer",
+      "email": "test@mail.com",
+      "metadata": {
+        "test": "key"
+      }
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 0,
+  "request": "req_9ryusbEBenV0BX",
+  "type": "customer.updated"
+}

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -91,56 +91,7 @@ defmodule Stripe.ConverterTest do
     }
   end
 
-  @event_response %{
-    "id" => "evt_19YEx1BKl1F6IRFfb1cFLHzZ",
-    "object" => "event",
-    "api_version" => "2016-07-06",
-    "created" => 1483537031,
-    "data" => %{
-      "object" => %{
-        "id" => "cus_9ryX7lUQ4Dcpf7",
-        "object" => "customer",
-        "account_balance" => 0,
-        "created" => 1483535628,
-        "currency" => nil,
-        "default_source" => nil,
-        "delinquent" => false,
-        "description" => nil,
-        "discount" => nil,
-        "email" => "test2@mail.com",
-        "livemode" => false,
-        "metadata" => %{},
-        "shipping" => nil,
-        "sources" => %{
-          "object" => "list",
-          "data" => [],
-          "has_more" => false,
-          "total_count" => 0,
-          "url" => "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources"
-        },
-        "subscriptions" => %{
-          "object" => "list",
-          "data" => [],
-          "has_more" => false,
-          "total_count" => 0,
-          "url" => "/v1/customers/cus_9ryX7lUQ4Dcpf7/subscriptions"
-        }
-      },
-      "previous_attributes" => %{
-        "description" => "testcustomer",
-        "email" => "test@mail.com",
-        "metadata" => %{
-          "test" => "key"
-        }
-      }
-    },
-    "livemode" => false,
-    "pending_webhooks" => 0,
-    "request" => "req_9ryusbEBenV0BX",
-    "type" => "customer.updated"
-  }
-
-  test "converts an event response properly" do
+  test "converts an object containing another object properly" do
     expected_result = %Stripe.Event{
       api_version: "2016-07-06",
       created: 1483537031,
@@ -156,7 +107,19 @@ defmodule Stripe.ConverterTest do
           email: "test2@mail.com",
           id: "cus_9ryX7lUQ4Dcpf7",
           livemode: false,
-          metadata: %{}
+          metadata: %{},
+          sources: %Stripe.List{
+            data: [],
+            has_more: false,
+            total_count: 0,
+            url: "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources"
+          },
+          subscriptions: %Stripe.List{
+            data: [],
+            has_more: false,
+            total_count: 0,
+            url: "/v1/customers/cus_9ryX7lUQ4Dcpf7/subscriptions"
+          }
         },
         previous_attributes: %{
           description: "testcustomer",
@@ -173,7 +136,103 @@ defmodule Stripe.ConverterTest do
       user_id: nil
     }
 
-    result = Converter.stripe_map_to_struct(Stripe.Event, @event_response)
+    fixture = Helper.load_fixture("event_with_customer.json")
+    result = Converter.stripe_map_to_struct(Stripe.Event, fixture)
+
+    assert result == expected_result
+  end
+
+  test "converts a list response properly" do
+    expected_result = %Stripe.List{
+      data: [
+        %Stripe.Card{
+          id: "card_19YDiuBKl1F6IRFflldIp6Dc",
+          address_city: nil,
+          address_country: nil,
+          address_line1: nil,
+          address_line1_check: nil,
+          address_line2: nil,
+          address_state: nil,
+          address_zip: nil,
+          address_zip_check: nil,
+          brand: "Visa",
+          country: "US",
+          customer: "cus_9ryX7lUQ4Dcpf7",
+          cvc_check: nil,
+          dynamic_last4: nil,
+          exp_month: 8,
+          exp_year: 2018,
+          funding: "credit",
+          last4: "4242",
+          metadata: %{},
+          name: nil,
+          tokenization_method: nil
+        },
+        %Stripe.Card{
+          id: "card_abcdiuBKl1F6IRFflldIp6Dc",
+          address_city: nil,
+          address_country: nil,
+          address_line1: nil,
+          address_line1_check: nil,
+          address_line2: nil,
+          address_state: nil,
+          address_zip: nil,
+          address_zip_check: nil,
+          brand: "Visa",
+          country: "US",
+          customer: "cus_9ryX7lUQ4Dcpf7",
+          cvc_check: nil,
+          dynamic_last4: nil,
+          exp_month: 12,
+          exp_year: 2020,
+          funding: "credit",
+          last4: "4242",
+          metadata: %{},
+          name: nil,
+          tokenization_method: nil
+        }
+      ],
+      has_more: false,
+      total_count: 2,
+      url: "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources"
+    }
+
+    fixture = Helper.load_fixture("card_list.json")
+    result = Converter.stripe_map_to_struct(Stripe.List, fixture)
+
+    assert result == expected_result
+  end
+
+  test "converts an object containing a list properly" do
+    expected_result = %Stripe.Customer{
+      id: "cus_9ryX7lUQ4Dcpf7",
+      account_balance: 0,
+      created: 1483535628,
+      currency: "usd",
+      default_source: nil,
+      delinquent: false,
+      description: nil,
+      discount: nil,
+      email: "test2@mail.com",
+      livemode: false,
+      metadata: %{},
+      shipping: nil,
+      sources: %Stripe.List{
+        data: [],
+        has_more: false,
+        total_count: 0,
+        url: "/v1/customers/cus_9ryX7lUQ4Dcpf7/sources"
+      },
+      subscriptions: %Stripe.List{
+        data: [],
+        has_more: false,
+        total_count: 0,
+        url: "/v1/customers/cus_9ryX7lUQ4Dcpf7/subscriptions"
+      }
+    }
+
+    fixture = Helper.load_fixture("customer.json")
+    result = Converter.stripe_map_to_struct(Stripe.Customer, fixture)
 
     assert result == expected_result
   end

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -13,6 +13,7 @@ defmodule Stripe.UtilTest do
       assert object_name_to_module("external_account") == Stripe.ExternalAccount
       assert object_name_to_module("file_upload") == Stripe.FileUpload
       assert object_name_to_module("invoice") == Stripe.Invoice
+      assert object_name_to_module("list") == Stripe.List
       assert object_name_to_module("plan") == Stripe.Plan
       assert object_name_to_module("subscription") == Stripe.Subscription
       assert object_name_to_module("token") == Stripe.Token

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,4 +3,9 @@ ExUnit.start
 ExUnit.configure [exclude: [disabled: true], seed: 0 ]
 
 defmodule Helper do
+	@fixture_path "./test/fixtures/"
+
+  def load_fixture(filename) do
+    File.read!(@fixture_path <> filename) |> Poison.decode!
+  end
 end


### PR DESCRIPTION
Closes #188 

This is a basic implementation of a list module. It allows us to serialize list objects.

It still lacks support of pagination and fetching the next page of objects if there are multiple, but that's more advanced and should probably be handled separately.

It should also support having lists whose elements are not all of the same type, but due to lack of supporting all stripe objects, I cannot find a use case that would work as a test.