### PR TITLE
Remove module argument reliance from converter

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -152,7 +152,7 @@ defmodule Stripe.Account do
   """
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, changes, @schema, opts)
   end
 
   @doc """
@@ -174,9 +174,7 @@ defmodule Stripe.Account do
   def retrieve(id, opts \\ []), do: do_retrieve(@plural_endpoint <> "/" <> id, opts)
 
   @spec do_retrieve(String.t, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  defp do_retrieve(endpoint, opts) do
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
-  end
+  defp do_retrieve(endpoint, opts), do: Stripe.Request.retrieve(endpoint, opts)
 
   @doc """
   Update an account.
@@ -186,6 +184,6 @@ defmodule Stripe.Account do
   @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
 end

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -106,7 +106,7 @@ defmodule Stripe.Card do
       |> Util.map_keys_to_atoms()
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(__MODULE__, result)}
+      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(result)}
       {:error, error} -> {:error, error}
     end
   end
@@ -125,7 +125,7 @@ defmodule Stripe.Card do
   @spec retrieve(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(owner_type, owner_id, card_id, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 
   @doc """
@@ -136,7 +136,7 @@ defmodule Stripe.Card do
   @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(owner_type, owner_id, card_id, changes, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
-    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/charge.ex
+++ b/lib/stripe/charge.ex
@@ -82,7 +82,7 @@ defmodule Stripe.Charge do
   """
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, changes, @schema, opts)
   end
 
   @doc """
@@ -91,6 +91,6 @@ defmodule Stripe.Charge do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 end

--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -73,7 +73,7 @@ defmodule Stripe.Connect.OAuth do
     }
 
     case Stripe.oauth_request(:post, endpoint, body) do
-       {:ok, result} -> {:ok, Converter.stripe_map_to_struct(TokenResponse, result)}
+       {:ok, result} -> {:ok, Converter.stripe_map_to_struct(result)}
        {:error, error} -> {:error, error}
      end
   end
@@ -98,7 +98,7 @@ defmodule Stripe.Connect.OAuth do
     }
 
     case Stripe.oauth_request(:post, endpoint, body) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(DeauthorizeResponse, result)}
+      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(result)}
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -4,52 +4,44 @@ defmodule Stripe.Converter do
   Takes the module (e.g. `Stripe.Card`) and the response from Stripe and
   returns a struct (e.g. `%Stripe.Card{}`) containing the Stripe response.
   """
-  @spec stripe_map_to_struct(module, %{String.t => any}) :: struct
-  def stripe_map_to_struct(module, response) do
-    struct_keys = Map.keys(module.__struct__) |> List.delete(:__struct__)
-
-    processed_map =
-      Enum.reduce(struct_keys, %{}, fn key, acc ->
-        string_key = to_string(key)
-        converted_value = Map.get(response, string_key) |> convert_value()
-        Map.put(acc, key, converted_value)
-      end)
-
-    struct(module, processed_map)
-  end
+  @spec stripe_map_to_struct(%{String.t => any}) :: struct
+  def stripe_map_to_struct(response), do: convert_stripe_object(response)
 
   @supported_objects ~w(account bank_account card customer event external_account file_upload invoice list plan subscription token)
 
-  # converts maps that are actually Stripe objects
+  @spec convert_value(any) :: any
   defp convert_value(%{"object" => object_name} = value) when is_binary(object_name) do
     case Enum.member?(@supported_objects, object_name) do
       true -> convert_stripe_object(value)
       false -> convert_map(value)
     end
   end
-
-  # converts plain maps
   defp convert_value(value) when is_map(value), do: convert_map(value)
-
-  # converts lists
   defp convert_value(value) when is_list(value), do: convert_list(value)
-
-  # converts anything else
   defp convert_value(value), do: value
 
+  @spec convert_map(map) :: map
   defp convert_map(value) do
     Enum.reduce(value, %{}, fn({key, value}, acc) ->
       Map.put(acc, String.to_atom(key), convert_value(value))
     end)
   end
 
+  @spec convert_stripe_object(%{String.t => any}) :: struct
   defp convert_stripe_object(%{"object" => object_name} = value) do
-    object_name
-    |> Stripe.Util.object_name_to_module
-    |> stripe_map_to_struct(value)
+    module = Stripe.Util.object_name_to_module(object_name)
+    struct_keys = Map.keys(module.__struct__) |> List.delete(:__struct__)
+
+    processed_map =
+      Enum.reduce(struct_keys, %{}, fn key, acc ->
+        string_key = to_string(key)
+        converted_value = Map.get(value, string_key) |> convert_value()
+        Map.put(acc, key, converted_value)
+      end)
+
+    struct(module, processed_map)
   end
 
-  defp convert_list(list) do
-    list |> Enum.map(&convert_value/1)
-  end
+  @spec convert_list(list) :: list
+  defp convert_list(list), do: list |> Enum.map(&convert_value/1)
 end

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -68,7 +68,7 @@ defmodule Stripe.Customer do
   """
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, changes, @schema, opts)
   end
 
   @doc """
@@ -77,7 +77,7 @@ defmodule Stripe.Customer do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 
   @doc """
@@ -88,7 +88,7 @@ defmodule Stripe.Customer do
   @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/event.ex
+++ b/lib/stripe/event.ex
@@ -27,6 +27,6 @@ defmodule Stripe.Event do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 end

--- a/lib/stripe/external_account.ex
+++ b/lib/stripe/external_account.ex
@@ -57,7 +57,7 @@ defmodule Stripe.ExternalAccount do
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(changes, opts = [connect_account: managed_account_id]) do
     endpoint = endpoint(managed_account_id)
-    Stripe.Request.create(endpoint, changes, @schema, __MODULE__, opts)
+    Stripe.Request.create(endpoint, changes, @schema, opts)
   end
 
   @doc """
@@ -66,7 +66,7 @@ defmodule Stripe.ExternalAccount do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts = [connect_account: managed_account_id]) do
     endpoint = endpoint(managed_account_id) <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 
   @doc """
@@ -77,7 +77,7 @@ defmodule Stripe.ExternalAccount do
   @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts = [connect_account: managed_account_id]) do
     endpoint = endpoint(managed_account_id) <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/file_upload.ex
+++ b/lib/stripe/file_upload.ex
@@ -26,7 +26,7 @@ defmodule Stripe.FileUpload do
   """
   @spec create(Path.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(filepath, purpose, opts \\ []) do
-    Stripe.Request.create_file_upload(@plural_endpoint, filepath, purpose, __MODULE__, opts)
+    Stripe.Request.create_file_upload(@plural_endpoint, filepath, purpose, opts)
   end
 
   @doc """
@@ -35,7 +35,7 @@ defmodule Stripe.FileUpload do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve_file_upload(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve_file_upload(endpoint, opts)
   end
 
 end

--- a/lib/stripe/invoice.ex
+++ b/lib/stripe/invoice.ex
@@ -70,7 +70,7 @@ defmodule Stripe.Invoice do
   """
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, changes, @schema, opts)
   end
 
   @doc """
@@ -79,7 +79,7 @@ defmodule Stripe.Invoice do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 
   @doc """
@@ -90,6 +90,6 @@ defmodule Stripe.Invoice do
   @spec update(binary, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
 end

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -48,7 +48,7 @@ defmodule Stripe.Plan do
   """
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, changes, @schema, opts)
   end
 
   @doc """
@@ -57,7 +57,7 @@ defmodule Stripe.Plan do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 
   @doc """
@@ -68,7 +68,7 @@ defmodule Stripe.Plan do
   @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -2,53 +2,40 @@ defmodule Stripe.Request do
   alias Stripe.Changeset
   alias Stripe.Converter
 
-  @spec create(String.t, map, map, module, Keyword.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
-  def create(endpoint, changes, schema, module, opts) do
-    body =
-      changes
-      |> Changeset.cast(schema, :create)
-
-    Stripe.request(:post, endpoint, body, %{}, opts)
-    |> handle_result(module)
+  @spec create(String.t, map, map, Keyword.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
+  def create(endpoint, changes, schema, opts) do
+    body = changes |> Changeset.cast(schema, :create)
+    Stripe.request(:post, endpoint, body, %{}, opts) |> handle_result()
   end
 
-  @spec create_file_upload(String.t, Path.t, String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def create_file_upload(endpoint, filepath, purpose, module, opts) do
+  @spec create_file_upload(String.t, Path.t, String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def create_file_upload(endpoint, filepath, purpose, opts) do
     body = {:multipart, [{"purpose", purpose}, {:file, filepath}]}
-    Stripe.request_file_upload(:post, endpoint, body, %{}, opts)
-    |> handle_result(module)
+    Stripe.request_file_upload(:post, endpoint, body, %{}, opts) |> handle_result()
   end
 
-  @spec retrieve(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def retrieve(endpoint, module, opts) do
-    Stripe.request(:get, endpoint, %{}, %{}, opts)
-    |> handle_result(module)
+  @spec retrieve(String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def retrieve(endpoint, opts) do
+    Stripe.request(:get, endpoint, %{}, %{}, opts) |> handle_result()
   end
 
-  @spec retrieve_file_upload(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def retrieve_file_upload(endpoint, module, opts) do
-    Stripe.request_file_upload(:get, endpoint, %{}, %{}, opts)
-    |> handle_result(module)
+  @spec retrieve_file_upload(String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def retrieve_file_upload(endpoint, opts) do
+    Stripe.request_file_upload(:get, endpoint, %{}, %{}, opts) |> handle_result()
   end
 
-  @spec update(String.t, map, map, list, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def update(endpoint, changes, schema, nullable_keys, module, opts) do
-    body =
-      changes
-      |> Changeset.cast(schema, :update, nullable_keys)
-
-    Stripe.request(:post, endpoint, body, %{}, opts)
-    |> handle_result(module)
+  @spec update(String.t, map, map, list, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def update(endpoint, changes, schema, nullable_keys, opts) do
+    body = changes |> Changeset.cast(schema, :update, nullable_keys)
+    Stripe.request(:post, endpoint, body, %{}, opts) |> handle_result()
   end
 
   @spec delete(String.t, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
   def delete(endpoint, opts) do
-    Stripe.request(:delete, endpoint, %{}, %{}, opts)
-    |> handle_result
+    Stripe.request(:delete, endpoint, %{}, %{}, opts) |> handle_result()
   end
 
-  defp handle_result(result, module \\ nil)
-  defp handle_result({:ok, _}, nil), do: :ok
-  defp handle_result({:ok, result = %{}}, module), do: {:ok, Converter.stripe_map_to_struct(module, result)}
-  defp handle_result({:error, error}, _), do: {:error, error}
+  defp handle_result(result)
+  defp handle_result({:ok, result = %{}}), do: {:ok, Converter.stripe_map_to_struct(result)}
+  defp handle_result({:error, error}), do: {:error, error}
 end

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -62,7 +62,7 @@ defmodule Stripe.Subscription do
   """
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, changes, @schema, opts)
   end
 
   @doc """
@@ -71,7 +71,7 @@ defmodule Stripe.Subscription do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 
   @doc """
@@ -82,7 +82,7 @@ defmodule Stripe.Subscription do
   @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
 
   @doc """

--- a/lib/stripe/token.ex
+++ b/lib/stripe/token.ex
@@ -50,7 +50,7 @@ defmodule Stripe.Token do
       card: customer_card_id,
       customer: customer_id
     }
-    Stripe.Request.create(@plural_endpoint, body, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, body, @schema, opts)
   end
 
   @doc """
@@ -64,7 +64,7 @@ defmodule Stripe.Token do
     body = %{
       customer: customer_id
     }
-    Stripe.Request.create(@plural_endpoint, body, @schema, __MODULE__, opts)
+    Stripe.Request.create(@plural_endpoint, body, @schema, opts)
   end
 
   @doc """
@@ -73,6 +73,6 @@ defmodule Stripe.Token do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
+    Stripe.Request.retrieve(endpoint, opts)
   end
 end

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -38,14 +38,6 @@ defmodule Stripe.Util do
     end)
   end
 
-  def string_map_to_atoms([string_key_map]) do
-    string_map_to_atoms string_key_map
-  end
-
-  def string_map_to_atoms(string_key_map) do
-    for {key, val} <- string_key_map, into: %{}, do: {String.to_atom(key), val}
-  end
-
   def atomize_keys(map = %{}) do
     Enum.into(map, %{}, fn {k, v} -> {atomize_key(k), atomize_keys(v)} end)
   end

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -2,97 +2,8 @@ defmodule Stripe.ConverterTest do
   use ExUnit.Case
 
   alias Stripe.Converter
-  alias Stripe.ConverterTest
 
-  defmodule Person do
-    defstruct [:email, :first_name, :last_name, :legal_entity, :metadata]
-  end
-
-  defmodule AuthToken do
-    defstruct [:id, :card, :client_ip, :created, :livemode, :type, :used]
-  end
-
-  test "converts a response into a struct" do
-    expected_result = %Stripe.ConverterTest.Person{
-      first_name: "Leslie",
-      last_name: "Knope",
-      email: "knope@stripe.com",
-      metadata: %{},
-      legal_entity: %{
-        address: %{
-          city: "Pawnee",
-          country: "US",
-          state: "IN"
-        },
-        business_name: "Parks and Rec",
-        dob: %{
-          day: 23,
-          month: 12,
-          year: 2016
-        }
-      }
-    }
-
-    result = Converter.stripe_map_to_struct(ConverterTest.Person, json_response())
-    assert result == expected_result
-  end
-
-  defp json_response do
-    %{
-      "first_name" => "Leslie",
-      "last_name" => "Knope",
-      "email" => "knope@stripe.com",
-      "metadata" => %{},
-      "legal_entity" => %{
-        "address" => %{
-          "city" => "Pawnee",
-          "country" => "US",
-          "state" => "IN"
-        },
-        "business_name" => "Parks and Rec",
-        "dob" => %{
-          "day" => 23,
-          "month" => 12,
-          "year" => 2016
-        }
-      }
-    }
-  end
-
-  test "converts a stripe card sub-object into a struct" do
-    expected_result = %Stripe.ConverterTest.AuthToken{
-      id: "token_id",
-      used: false,
-      card: %Stripe.Card{
-        object: "card",
-        brand: "Visa",
-        country: "US",
-        exp_month: 8
-      },
-      created: 1462905445
-    }
-
-    result = Converter.stripe_map_to_struct(
-      ConverterTest.AuthToken, json_response_with_card_subobject()
-    )
-    assert result == expected_result
-  end
-
-  defp json_response_with_card_subobject do
-    %{
-      "id" => "token_id",
-      "used" => false,
-      "created" => 1462905445,
-      "card" => %{
-        "object" => "card",
-        "brand" => "Visa",
-        "country" => "US",
-        "exp_month" => 8,
-      }
-    }
-  end
-
-  test "converts an object containing another object properly" do
+  test "converts a 'customer.updated' event response properly" do
     expected_result = %Stripe.Event{
       api_version: "2016-07-06",
       created: 1483537031,
@@ -141,7 +52,7 @@ defmodule Stripe.ConverterTest do
     }
 
     fixture = Helper.load_fixture("event_with_customer.json")
-    result = Converter.stripe_map_to_struct(Stripe.Event, fixture)
+    result = Converter.stripe_map_to_struct(fixture)
 
     assert result == expected_result
   end
@@ -205,12 +116,12 @@ defmodule Stripe.ConverterTest do
     }
 
     fixture = Helper.load_fixture("card_list.json")
-    result = Converter.stripe_map_to_struct(Stripe.List, fixture)
+    result = Converter.stripe_map_to_struct(fixture)
 
     assert result == expected_result
   end
 
-  test "converts an object containing a list properly" do
+  test "converts a customer response with a list of sources properly" do
     expected_result = %Stripe.Customer{
       id: "cus_9ryX7lUQ4Dcpf7",
       object: "customer",
@@ -242,7 +153,7 @@ defmodule Stripe.ConverterTest do
     }
 
     fixture = Helper.load_fixture("customer.json")
-    result = Converter.stripe_map_to_struct(Stripe.Customer, fixture)
+    result = Converter.stripe_map_to_struct(fixture)
 
     assert result == expected_result
   end


### PR DESCRIPTION
Closes #189 

This completely removes the need to pass in a module to `Converter.stripe_map_to_struct`. Instead, since all base level response object have an "object" key, the module is inferred from that.

This also means we do not need to pass in the module to `Stripe.Request.x` either.