### PR TITLE
Add Stripe.Token.create

### DIFF
--- a/lib/stripe/token.ex
+++ b/lib/stripe/token.ex
@@ -5,6 +5,7 @@ defmodule Stripe.Token do
   You can:
 
   - Create a token for a Connect customer with a card
+  - Create a token with all options - Only for Unit Tests with Stripe
   - Retrieve a token
 
   Does not yet render lists or take options.
@@ -65,6 +66,19 @@ defmodule Stripe.Token do
       customer: customer_id
     }
     Stripe.Request.create(@plural_endpoint, body, @schema, __MODULE__, opts)
+  end
+
+  @doc """
+  Create a token.
+
+  WARNING : This function is mainly for testing purposes only, you should not use
+  it on a production server, unless you are able to transfer and store credit card
+  data on your server in a PCI compliance way.
+  Use the Stripe.js library on the client device instead.
+  """
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(changes, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, changes, @schema, __MODULE__, opts)
   end
 
   @doc """


### PR DESCRIPTION
This function is meant to be only used in Unit Tests to simulate a token provided by the client.