### PR TITLE
Ensure strict functions call with parentheses to avoid warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Stripe.Mixfile do
   def project do
     [
       app: :stripity_stripe,
-      deps: deps,
+      deps: deps(),
       description: description(),
       elixir: "~> 1.3",
       package: package(),


### PR DESCRIPTION
I just moved to Elixir 1.4 and there's now a warning on strict calling for functions missing parentheses.

Here's a fix for stripity_stripe