### PR TITLE
Add request helper to reduce duplication.

### DIFF
--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -8,35 +8,27 @@ defmodule Stripe.Request do
       changes
       |> Changeset.cast(schema, :create)
 
-    case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(module, result)}
-      {:error, error} -> {:error, error}
-    end
+    Stripe.request(:post, endpoint, body, %{}, opts)
+    |> handle_result(module)
   end
 
   @spec create_file_upload(String.t, Path.t, String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def create_file_upload(endpoint, filepath, purpose, module, opts) do
     body = {:multipart, [{"purpose", purpose}, {:file, filepath}]}
-    case Stripe.request_file_upload(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(module, result)}
-      {:error, error} -> {:error, error}
-    end
+    Stripe.request_file_upload(:post, endpoint, body, %{}, opts)
+    |> handle_result(module)
   end
 
   @spec retrieve(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def retrieve(endpoint, module, opts) do
-    case Stripe.request(:get, endpoint, %{}, %{}, opts) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(module, result)}
-      {:error, error} -> {:error, error}
-    end
+    Stripe.request(:get, endpoint, %{}, %{}, opts)
+    |> handle_result(module)
   end
 
   @spec retrieve_file_upload(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def retrieve_file_upload(endpoint, module, opts) do
-    case Stripe.request_file_upload(:get, endpoint, %{}, %{}, opts) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(module, result)}
-      {:error, error} -> {:error, error}
-    end
+    Stripe.request_file_upload(:get, endpoint, %{}, %{}, opts)
+    |> handle_result(module)
   end
 
   @spec update(String.t, map, map, list, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
@@ -45,17 +37,18 @@ defmodule Stripe.Request do
       changes
       |> Changeset.cast(schema, :update, nullable_keys)
 
-    case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(module, result)}
-      {:error, error} -> {:error, error}
-    end
+    Stripe.request(:post, endpoint, body, %{}, opts)
+    |> handle_result(module)
   end
 
   @spec delete(String.t, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
   def delete(endpoint, opts) do
-    case Stripe.request(:delete, endpoint, %{}, %{}, opts) do
-      {:ok, _} -> :ok
-      {:error, error} -> {:error, error}
-    end
+    Stripe.request(:delete, endpoint, %{}, %{}, opts)
+    |> handle_result
   end
+
+  defp handle_result(result, module \\ nil)
+  defp handle_result({:ok, _}, nil), do: :ok
+  defp handle_result({:ok, result = %{}}, module), do: {:ok, Converter.stripe_map_to_struct(module, result)}
+  defp handle_result({:error, error}, _), do: {:error, error}
 end


### PR DESCRIPTION
Coverage went down somehow, though this is the same code, more or less. This also suggests an obvious API change that I would like to propose -- making body be the first argument of `Stripe.Request`.  In the case of e.g. `update`, it would look like:

```
  @spec update(String.t, map, map, list, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
  def update(endpoint, changes, schema, nullable_keys, module, opts) do
    changes
    |> Changeset.cast(schema, :update, nullable_keys)
    |> Stripe.request(:post, endpoint, %{}, opts)
    |> handle_result(module)
  end
```

I have this done locally and it looks pretty clean throughout. I can push to this branch if you all want, or a new one. This module would look like: https://gist.github.com/asummers/49384f353da45752b0cbb3ed61cbdc01 with `handle_result` being public because it is used in `Stripe.Card.create/4`. 