### PR TITLE
Add Retrieve Many and Retrieve All For Cards. 

### DIFF
--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -141,13 +141,9 @@ defmodule Stripe.Card do
     Stripe.Request.retrieve_many(endpoint, __MODULE__, opts)
   end
 
-  @spec retrieve_all(source, String.t, Keyword.t) :: {:ok, [t]}
+  @spec retrieve_all(source, String.t, Keyword.t) :: {:ok, [t]} | {:error, Stripe.api_error_struct}
   def retrieve_all(owner_type, owner_id, opts \\ []) do
-    all =
-      fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end
-      |> Stripe.Request.stream(opts)
-      |> Enum.to_list
-    {:ok, all}
+    Stripe.Stquest.retrieve_all(fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end)
   end
 
   @doc """

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -143,7 +143,7 @@ defmodule Stripe.Card do
 
   @spec retrieve_all(source, String.t, Keyword.t) :: {:ok, [t]} | {:error, Stripe.api_error_struct}
   def retrieve_all(owner_type, owner_id, opts \\ []) do
-    Stripe.Stquest.retrieve_all(fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end)
+    Stripe.Request.retrieve_all(fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end)
   end
 
   @doc """

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -128,6 +128,28 @@ defmodule Stripe.Card do
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 
+  @spec retrieve_many(source, String.t, Keyword.t) :: {:ok, boolean, [t]} | {:error, Stripe.api_error_struct}
+  def retrieve_many(owner_type, owner_id, opts \\ []) do
+    query =
+      %{object: "card"}
+      |> Util.put_if_non_nil_opt(:starting_after, opts)
+      |> Util.put_if_non_nil_opt(:ending_before, opts)
+      |> Util.put_if_non_nil_opt(:limit, opts)
+      |> URI.encode_query
+    endpoint = endpoint_for_owner(owner_type, owner_id) <> "?" <> query
+
+    Stripe.Request.retrieve_many(endpoint, __MODULE__, opts)
+  end
+
+  @spec retrieve_all(source, String.t, Keyword.t) :: {:ok, [t]}
+  def retrieve_all(owner_type, owner_id, opts \\ []) do
+    all =
+      fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end
+      |> Stripe.Request.stream(opts)
+      |> Enum.to_list
+    {:ok, all}
+  end
+
   @doc """
   Update a card.
 

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -143,7 +143,7 @@ defmodule Stripe.Card do
 
   @spec retrieve_all(source, String.t, Keyword.t) :: {:ok, [t]} | {:error, Stripe.api_error_struct}
   def retrieve_all(owner_type, owner_id, opts \\ []) do
-    Stripe.Request.retrieve_all(fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end)
+    Stripe.Request.retrieve_all(fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end, opts)
   end
 
   @doc """

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -65,7 +65,7 @@ defmodule Stripe.Request do
         |> Stripe.Request.stream(opts)
         |> Enum.to_list
       {:ok, all}
-    rescue
+    catch
       error -> {:error, error}
     end
   end
@@ -88,9 +88,9 @@ defmodule Stripe.Request do
             end
 
           case retrieve_many.(opts_list) do
-            # Unfortunately we have to raise here to break out of Stream.
-            # But this can easily be rescued and error tuple-ized.
-            {:error, error} -> raise error
+            # Unfortunately we have to throw here to break out of Stream.
+            # But this can easily be caught and error tuple-ized.
+            {:error, error} -> throw error
             {:ok, false, results} -> {results, false}
             {:ok, true, results} ->
               last_result_id =

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -88,6 +88,8 @@ defmodule Stripe.Request do
             end
 
           case retrieve_many.(opts_list) do
+            # Unfortunately we have to raise here to break out of Stream.
+            # But this can easily be rescued and error tuple-ized.
             {:error, error} -> raise error
             {:ok, false, results} -> {results, false}
             {:ok, true, results} ->

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -57,8 +57,8 @@ defmodule Stripe.Request do
     |> handle_result
   end
 
-  @spec retrieve_all(function) :: {:ok, [struct]} | {:error, Stripe.api_error_struct}
-  def retrieve_all(retrieve_many, opts \\ []) do
+  @spec retrieve_all(function, Keyword.t) :: {:ok, [struct]} | {:error, Stripe.api_error_struct}
+  def retrieve_all(retrieve_many, opts) do
     try do
       all =
         retrieve_many

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -58,7 +58,7 @@ defmodule Stripe.Request do
   end
 
   @doc """
-  Wraps call to `stream/` in try/catch and wraps results in result tuple.
+  Wraps call to `Stripe.Request.stream/2` in try/catch and wraps results in result tuple.
   """
   @spec retrieve_all(function, Keyword.t) :: {:ok, [struct]} | {:error, Stripe.api_error_struct}
   def retrieve_all(retrieve_many, opts) do
@@ -76,9 +76,12 @@ defmodule Stripe.Request do
   @doc """
   Retrieve all entities from the Stripe API.
 
-  How it works is that it effectively calls retrieve_many/3 and chains
-  successive calls together, collecting the results into an
-  Enumerable, overwriting the opts each time.
+  How it works is that it effectively calls retrieve_many from e.g.
+  `Stripe.Card` and chains successive calls together, collecting the
+  results, overwriting the opts each time using the Stripe pagination
+  mechanisms of taking the last id you've seen and retrieving all
+  results starting past that id, up to `limit`. See Stripe documentation
+  for details on parameter values.
 
   The argument `retrieve_many` should be a one argument function that
   takes in the new opts to pass to retrieve_many. If there is an

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -57,6 +57,9 @@ defmodule Stripe.Request do
     |> handle_result
   end
 
+  @doc """
+  Wraps call to `stream/` in try/catch and wraps results in result tuple.
+  """
   @spec retrieve_all(function, Keyword.t) :: {:ok, [struct]} | {:error, Stripe.api_error_struct}
   def retrieve_all(retrieve_many, opts) do
     try do
@@ -70,6 +73,25 @@ defmodule Stripe.Request do
     end
   end
 
+  @doc """
+  Retrieve all entities from the Stripe API.
+
+  How it works is that it effectively calls retrieve_many/3 and chains
+  successive calls together, collecting the results into an
+  Enumerable, overwriting the opts each time.
+
+  The argument `retrieve_many` should be a one argument function that
+  takes in the new opts to pass to retrieve_many. If there is an
+  error, the error is thrown since there is no good way otherwise to
+  signal an error within `Stream.resource`.
+
+  Example:
+  ```
+  retrieve_many = fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end, opts
+  opts = []
+  stream(retrieve_many, opts)
+  ````
+  """
   @spec stream(function, Keyword.t) :: Enumerable.t | no_return
   def stream(retrieve_many, opts) do
     initial_opts = Keyword.take(opts, [:starting_after, :ending_before])

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -57,7 +57,7 @@ defmodule Stripe.Request do
     |> handle_result
   end
 
-  @spec retrieve_all(function) :: {:ok, [t]} | {:error, Stripe.api_error_struct}
+  @spec retrieve_all(function) :: {:ok, [struct]} | {:error, Stripe.api_error_struct}
   def retrieve_all(retrieve_many, opts \\ []) do
     try do
       all =

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -87,7 +87,7 @@ defmodule Stripe.Request do
 
   Example:
   ```
-  retrieve_many = fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end, opts
+  retrieve_many = fn opts_list -> retrieve_many(owner_type, owner_id, opts_list) end
   opts = []
   stream(retrieve_many, opts)
   ````

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -66,4 +66,14 @@ defmodule Stripe.Util do
 
     Module.concat("Stripe", module_name)
   end
+
+  @spec put_if_non_nil_opt(map, atom, Keyword.t) :: map
+  def put_if_non_nil_opt(map, opt, opts) do
+    opt_value = Keyword.get(opts, opt)
+    if opt_value == nil do
+      map
+    else
+      Map.put(map, opt, opt_value)
+    end
+  end
 end

--- a/test/stripe/request_test.exs
+++ b/test/stripe/request_test.exs
@@ -8,5 +8,12 @@ defmodule Stripe.RequestTest do
       result = Stripe.Request.retrieve_all(retrieve_many, opts)
       assert result == {:error, "error"}
     end
+
+    test "handles no more correctly" do
+      opts = []
+      retrieve_many = fn _ -> {:ok, false, [:a, :b, :c]} end
+      result = Stripe.Request.retrieve_all(retrieve_many, opts)
+      assert result == {:ok, [:a, :b, :c]}
+    end
   end
 end

--- a/test/stripe/request_test.exs
+++ b/test/stripe/request_test.exs
@@ -1,0 +1,12 @@
+defmodule Stripe.RequestTest do
+  use ExUnit.Case
+
+  describe "retrieve_all/2" do
+    test "handles raised errors accurately" do
+      opts = []
+      retrieve_many = fn _ -> {:error, "error"} end
+      result = Stripe.Request.retrieve_all(retrieve_many, opts)
+      assert result == {:error, "error"}
+    end
+  end
+end

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -4,7 +4,7 @@ defmodule Stripe.UtilTest do
   import Stripe.Util
 
   describe "object_name_to_module/1" do
-  	test "converts all object names to their proper modules" do
+    test "converts all object names to their proper modules" do
       assert object_name_to_module("account") == Stripe.Account
       assert object_name_to_module("bank_account") == Stripe.ExternalAccount
       assert object_name_to_module("card") == Stripe.Card
@@ -17,6 +17,44 @@ defmodule Stripe.UtilTest do
       assert object_name_to_module("plan") == Stripe.Plan
       assert object_name_to_module("subscription") == Stripe.Subscription
       assert object_name_to_module("token") == Stripe.Token
+    end
+  end
+
+  describe "put_if_non_nil_opt/3" do
+    test "Puts if non nil" do
+      map = %{}
+      opt = :opt
+      opts = [opt: :non_nil]
+
+      result = put_if_non_nil_opt(map, opt, opts)
+      assert :opt in Map.keys(result)
+    end
+
+    test "Puts if false" do
+      map = %{}
+      opt = :opt
+      opts = [opt: false]
+
+      result = put_if_non_nil_opt(map, opt, opts)
+      assert :opt in Map.keys(result)
+    end
+
+    test "Does not put if absent" do
+      map = %{}
+      opt = :opt
+      opts = []
+
+      result = put_if_non_nil_opt(map, opt, opts)
+      assert not :opt in Map.keys(result)
+    end
+
+    test "Does not put if nil" do
+      map = %{}
+      opt = :opt
+      opts = [opt: nil]
+
+      result = put_if_non_nil_opt(map, opt, opts)
+      assert not :opt in Map.keys(result)
     end
   end
 end


### PR DESCRIPTION
Adds some primitives to make this easier to do in other endpoints. It is likely that even more of retrieve_many will get pulled down into `Stripe.Request.retrieve_many`. Original code from @DavidAntaramian then retrofitted and hardened.