### PR TITLE
Change parameter order for Stripe.request and updated all calls.

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -302,11 +302,11 @@ defmodule Stripe do
   utilizing the Connect program, you can pass the other Stripe account's
   ID to the request function as follows:
 
-      request(:get, "/customers", %{}, %{}, connect_account: "acc_134151")
+      request(%{}, :get, "/customers", %{}, connect_account: "acc_134151")
 
   """
-  @spec request(method, String.t, map, headers, list) :: {:ok, map} | {:error, api_error_struct}
-  def request(method, endpoint, body, headers, opts) do
+  @spec request(body, method, String.t, headers, list) :: {:ok, map} | {:error, api_error_struct}
+  def request(body, method, endpoint, headers, opts) do
     {connect_account_id, opts} = Keyword.pop(opts, :connect_account)
     {api_key, opts} = Keyword.pop(opts, :api_key)
 
@@ -331,8 +331,8 @@ defmodule Stripe do
 
   @doc """
   """
-  @spec request_file_upload(method, String.t, body, headers, list) :: {:ok, map} | {:error, api_error_struct}
-  def request_file_upload(method, endpoint, body, headers, opts) do
+  @spec request_file_upload(body, method, String.t, headers, list) :: {:ok, map} | {:error, api_error_struct}
+  def request_file_upload(body, method, endpoint, headers, opts) do
     {connect_account_id, opts} = Keyword.pop(opts, :connect_account)
     {api_key, opts} = Keyword.pop(opts, :api_key)
 

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -101,14 +101,11 @@ defmodule Stripe.Card do
   @spec create(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(owner_type, owner_id, token, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id)
-    body =
-      to_create_body(owner_type, token)
-      |> Util.map_keys_to_atoms()
 
-    case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Converter.stripe_map_to_struct(__MODULE__, result)}
-      {:error, error} -> {:error, error}
-    end
+    to_create_body(owner_type, token)
+    |> Util.map_keys_to_atoms()
+    |> Stripe.request(:post, endpoint, %{}, opts)
+    |> Stripe.Request.handle_result(__MODULE__)
   end
 
   @spec to_create_body(source, String.t) :: map

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -4,51 +4,52 @@ defmodule Stripe.Request do
 
   @spec create(String.t, map, map, module, Keyword.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
   def create(endpoint, changes, schema, module, opts) do
-    body =
-      changes
-      |> Changeset.cast(schema, :create)
-
-    Stripe.request(:post, endpoint, body, %{}, opts)
+    changes
+    |> Changeset.cast(schema, :create)
+    |> Stripe.request(:post, endpoint, %{}, opts)
     |> handle_result(module)
   end
 
   @spec create_file_upload(String.t, Path.t, String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def create_file_upload(endpoint, filepath, purpose, module, opts) do
     body = {:multipart, [{"purpose", purpose}, {:file, filepath}]}
-    Stripe.request_file_upload(:post, endpoint, body, %{}, opts)
+
+    body
+    |> Stripe.request_file_upload(:post, endpoint, %{}, opts)
     |> handle_result(module)
   end
 
   @spec retrieve(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def retrieve(endpoint, module, opts) do
-    Stripe.request(:get, endpoint, %{}, %{}, opts)
+    %{}
+    |> Stripe.request(:get, endpoint, %{}, opts)
     |> handle_result(module)
   end
 
   @spec retrieve_file_upload(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def retrieve_file_upload(endpoint, module, opts) do
-    Stripe.request_file_upload(:get, endpoint, %{}, %{}, opts)
+    %{}
+    |> Stripe.request_file_upload(:get, endpoint, %{}, opts)
     |> handle_result(module)
   end
 
   @spec update(String.t, map, map, list, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def update(endpoint, changes, schema, nullable_keys, module, opts) do
-    body =
-      changes
-      |> Changeset.cast(schema, :update, nullable_keys)
-
-    Stripe.request(:post, endpoint, body, %{}, opts)
+    changes
+    |> Changeset.cast(schema, :update, nullable_keys)
+    |> Stripe.request(:post, endpoint, %{}, opts)
     |> handle_result(module)
   end
 
   @spec delete(String.t, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
   def delete(endpoint, opts) do
-    Stripe.request(:delete, endpoint, %{}, %{}, opts)
+    %{}
+    |> Stripe.request(:delete, endpoint, %{}, opts)
     |> handle_result
   end
 
-  defp handle_result(result, module \\ nil)
-  defp handle_result({:ok, _}, nil), do: :ok
-  defp handle_result({:ok, result = %{}}, module), do: {:ok, Converter.stripe_map_to_struct(module, result)}
-  defp handle_result({:error, error}, _), do: {:error, error}
+  def handle_result(result, module \\ nil)
+  def handle_result({:ok, _}, nil), do: :ok
+  def handle_result({:ok, result = %{}}, module), do: {:ok, Converter.stripe_map_to_struct(module, result)}
+  def handle_result({:error, error}, _), do: {:error, error}
 end


### PR DESCRIPTION
This allows pipelining the request body through as the first argument of Stripe.request, resulting in a cleaner request module, when used in combination in combination with `handle_result`. 