### PR TITLE
Fix dialyzer and compiler warnings, bonus bugfix

### DIFF
--- a/lib/stripe/invoice.ex
+++ b/lib/stripe/invoice.ex
@@ -87,9 +87,9 @@ defmodule Stripe.Invoice do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec update(binary, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @schema, __MODULE__, @nullable_keys, opts)
+    Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, __MODULE__, opts)
   end
 end

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -33,7 +33,7 @@ defmodule Stripe.ConverterTest do
       }
     }
 
-    result = Converter.stripe_map_to_struct(ConverterTest.Person, json_response)
+    result = Converter.stripe_map_to_struct(ConverterTest.Person, json_response())
     assert result == expected_result
   end
 
@@ -73,7 +73,7 @@ defmodule Stripe.ConverterTest do
     }
 
     result = Converter.stripe_map_to_struct(
-      ConverterTest.AuthToken, json_response_with_card_subobject
+      ConverterTest.AuthToken, json_response_with_card_subobject()
     )
     assert result == expected_result
   end


### PR DESCRIPTION
Dialyzer was complaining about Stripe.invoice.update/3 because it was calling the update function with the wrong argument order. Fixed compiler warnings in tests while I was in here.

Since dialyzer is now 100% green, we should consider adding it to the CI pipeline. Any objections to that as a follow up to this PR? We should also consider enabling `--warnings-as-errors` for the compiler, it keeps people honest. 