### PR TITLE
Add parameters to DELETE requests (#222)

### DIFF
--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -139,6 +139,6 @@ defmodule Stripe.Card do
   @spec delete(source, String.t, String.t, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
   def delete(owner_type, owner_id, card_id, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
-    Stripe.Request.delete(endpoint, opts)
+    Stripe.Request.delete(endpoint, %{}, opts)
   end
 end

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -97,6 +97,6 @@ defmodule Stripe.Customer do
   @spec delete(binary, list) :: :ok | {:error, Stripe.api_error_struct}
   def delete(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.delete(endpoint, opts)
+    Stripe.Request.delete(endpoint, %{}, opts)
   end
 end

--- a/lib/stripe/external_account.ex
+++ b/lib/stripe/external_account.ex
@@ -86,6 +86,6 @@ defmodule Stripe.ExternalAccount do
   @spec delete(binary, list) :: :ok | {:error, Stripe.api_error_struct}
   def delete(id, opts = [connect_account: managed_account_id]) do
     endpoint = endpoint(managed_account_id) <> "/" <> id
-    Stripe.Request.delete(endpoint, opts)
+    Stripe.Request.delete(endpoint, %{}, opts)
   end
 end

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -77,6 +77,6 @@ defmodule Stripe.Plan do
   @spec delete(binary, list) :: :ok | {:error, Stripe.api_error_struct}
   def delete(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.delete(endpoint, opts)
+    Stripe.Request.delete(endpoint, %{}, opts)
   end
 end

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -41,9 +41,9 @@ defmodule Stripe.Request do
     |> handle_result
   end
 
-  @spec delete(String.t, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
-  def delete(endpoint, opts) do
-    %{}
+  @spec delete(String.t, map, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
+  def delete(endpoint, params, opts) do
+    params
     |> Stripe.request(:delete, endpoint, %{}, opts)
     |> handle_result
   end

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -87,10 +87,12 @@ defmodule Stripe.Subscription do
 
   @doc """
   Delete a subscription.
+
+  Takes the `id` and an optional map of `params`.
   """
-  @spec delete(binary, list) :: :ok | {:error, Stripe.api_error_struct}
-  def delete(id, opts \\ []) do
+  @spec delete(binary, map, list) :: :ok | {:error, Stripe.api_error_struct}
+  def delete(id, params \\ %{}, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.delete(endpoint, opts)
+    Stripe.Request.delete(endpoint, params, opts)
   end
 end


### PR DESCRIPTION
Support passing parameters to DELETE requests, e.g. [`at_period_end=true`](https://stripe.com/docs/api#cancel_subscription) when cancelling a subscription.