### PR TITLE
Add support for fetching next page of records to Stripe.List

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -7,7 +7,7 @@ defmodule Stripe.Converter do
   @spec stripe_map_to_struct(%{String.t => any}) :: struct
   def stripe_map_to_struct(response), do: convert_stripe_object(response)
 
-  @supported_objects ~w(account bank_account card customer event external_account file_upload invoice list plan subscription token)
+  @supported_objects ~w(account bank_account card country_spec customer event external_account file_upload invoice list plan subscription token)
 
   @spec convert_value(any) :: any
   defp convert_value(%{"object" => object_name} = value) when is_binary(object_name) do

--- a/lib/stripe/country_spec.ex
+++ b/lib/stripe/country_spec.ex
@@ -1,0 +1,40 @@
+defmodule Stripe.CountrySpec do
+  alias Stripe.Converter
+
+  @moduledoc """
+  Work with Stripe country specs objects.
+
+  You can:
+  - Retrieve a country spec
+  - Retrieve a list of country specs
+
+  Stripe API reference: https://stripe.com/docs/api#country_specs
+  """
+  @type t :: %__MODULE__{}
+
+  defstruct [
+    :id, :object,
+    :default_currency, :supported_bank_account_currencies,
+    :supported_payment_currencies, :supported_payment_methods,
+    :verification_fields
+  ]
+
+  @endpoint "country_specs"
+
+  @doc """
+  Retrieve a country spec.
+  """
+  @spec retrieve(binary) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def retrieve(country) do
+    path = @endpoint <> "/" <> country
+    Stripe.Request.retrieve(path, [])
+  end
+
+  @doc """
+  Retrieve a list of country specs.
+  """
+  @spec retrieve_all() :: {:ok, Map.t} | {:error, Stripe.api_error_struct}
+  def retrieve_all do
+    Stripe.Request.retrieve_all(@endpoint)
+  end
+end

--- a/lib/stripe/list.ex
+++ b/lib/stripe/list.ex
@@ -15,5 +15,5 @@ defmodule Stripe.List do
 
   @type t :: %__MODULE__{}
 
-  defstruct [:object, :data, :has_more, :total_count, :url]
+  defstruct [:object, :limit, :data, :has_more, :total_count, :url]
 end

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -2,6 +2,8 @@ defmodule Stripe.Request do
   alias Stripe.Changeset
   alias Stripe.Converter
 
+  @max_stripe_pagination_limit 100
+
   @spec create(String.t, map, map, Keyword.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
   def create(endpoint, changes, schema, opts) do
     changes
@@ -26,6 +28,45 @@ defmodule Stripe.Request do
     |> handle_result
   end
 
+  @doc """
+  Returns %Stripe.List{} of items, using pagination parameters
+
+  ## Example
+  retrieve_many(%{limit: 10, starting_after: 3}, "country_specs", []) => {:ok, %Stripe.List{}}
+
+  For more information on pagination parameters read Stripe docs:
+  https://stripe.com/docs/api#pagination
+  """
+  @spec retrieve_many(map, String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def retrieve_many(pagination_params, endpoint, opts \\ []) do
+    Stripe.request(pagination_params, :get, endpoint, %{}, opts)
+    |> handle_result_list(pagination_params, endpoint)
+  end
+
+  @doc """
+  Returns %Stripe.List{} of all items
+
+  ## Example
+  retrieve_all("country_specs") => {:ok, %Stripe.List{}}
+  """
+  @spec retrieve_all(String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def retrieve_all(endpoint, opts \\ []) do
+    aggregate_lists(retrieve_many(%{limit: @max_stripe_pagination_limit}, endpoint, opts), [])
+  end
+
+  @doc """
+  Returns %Stripe.List{} with next set of items, using previously fetched %Stripe.List{}
+
+  ## Example
+  {:ok, l} = retrieve_many(%{limit: 10}, "country_specs")
+  l |> retrieve_next => {:ok, %Stripe.List{10..20}}
+  """
+  @spec retrieve_next(Stripe.List.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def retrieve_next(%Stripe.List{limit: limit, url: url, data: data}, opts \\ []) do
+    %{id: starting_after} = List.last(data)
+    retrieve_many(%{starting_after: starting_after, limit: limit}, url, opts)
+  end
+
   @spec retrieve_file_upload(String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def retrieve_file_upload(endpoint, opts) do
     %{}
@@ -46,6 +87,27 @@ defmodule Stripe.Request do
     %{}
     |> Stripe.request(:delete, endpoint, %{}, opts)
     |> handle_result
+  end
+
+  defp aggregate_lists(response, aggr) do
+    case response do
+      {:error, error} -> {:error, error}
+      {:ok, %{has_more: false, data: data} = list} ->
+        {:ok, Map.put(list, :data, Enum.concat(aggr, data))}
+      {:ok, %{has_more: true, data: data} = list} ->
+        aggregate_lists(retrieve_next(list, []), Enum.concat(aggr, data))
+    end
+  end
+
+  defp handle_result_list(result, pagination_params, endpoint) do
+    with {:ok, handled_result} <- handle_result(result) do
+      {:ok, Map.merge(handled_result, %{
+        limit: pagination_params.limit,
+        url: endpoint
+      })}
+    else
+      {:error, error} -> {:error, error}
+    end
   end
 
   defp handle_result({:ok, result = %{}}), do: {:ok, Converter.stripe_map_to_struct(result)}

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -38,7 +38,7 @@ defmodule Stripe.Request do
   https://stripe.com/docs/api#pagination
   """
   @spec retrieve_many(map, String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def retrieve_many(pagination_params, endpoint, opts \\ []) do
+  def retrieve_many(%{limit: _} = pagination_params, endpoint, opts \\ []) do
     Stripe.request(pagination_params, :get, endpoint, %{}, opts)
     |> handle_result_list(pagination_params, endpoint)
   end


### PR DESCRIPTION
# Half-ready, intended for discussion.

closes #192 

Hi @asummers, @DavidAntaramian . I've found related PR (https://github.com/code-corps/stripity_stripe/pull/209). What's the progress on it?

I've implemented similar thing with a few differences:
- generic `retrieve_many`, since all entities seem to follow same pagination protocol.
- reused `handle_result` in `handle_result_list`.
- used recursion instead of Stream for `retrieve_all`.

Not sure this provides any benefits over your implementation. 
Maybe you'll find something useful.