### PR TITLE
Make API base url configurable

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -45,13 +45,25 @@ defmodule Stripe do
   end
 
   @doc """
-  Creates the URL for our endpoint.
+  Creates the URL for our endpoint. You can also manually set API base url
+  for testing purpose by configuring the :stripity_stripe application
+  with `:api_base_url` key. By default `https://api.stripe.com/v1/`.
+  Here is an example:
+
+      iex> Application.put_env(:stripity_stripe, :api_base_url, "http://localhost:4004")
+      :ok
+
+      iex> Stripe.process_url("/plans")
+      "http://localhost:4004/plans"
+
   Args:
     * endpoint - part of the API we're hitting
+
   Returns string
   """
   def process_url(endpoint) do
-    "https://api.stripe.com/v1/" <> endpoint
+    api_base_url = Application.get_env(:stripity_stripe, :api_base_url, "https://api.stripe.com/v1/")
+    api_base_url <> endpoint
   end
 
   @doc """

--- a/test/stripe/stripe_test.exs
+++ b/test/stripe/stripe_test.exs
@@ -7,6 +7,14 @@ defmodule Stripe.StripeTest do
     assert Stripe.process_url("payment") == "https://api.stripe.com/v1/payment"
   end
 
+  test "process_url when base_url from config" do
+    :ok = Application.put_env(:stripity_stripe, :api_base_url, "http://localhost:4000/")
+
+    assert Stripe.process_url("plans") == "http://localhost:4000/plans"
+
+    :ok = Application.delete_env(:stripity_stripe, :api_base_url)
+  end
+
   # test "make_request_with_key fails when no key is supplied on environment config" do
   #   with_mock System, [get_env: fn(_opts) -> nil end] do
   #     assert_raise Stripe.MissingSecretKeyError, fn ->


### PR DESCRIPTION
Convenient when you need to test api calls, for example with the Bypass library