### PR TITLE
Allow refunds to reverse transfers

### DIFF
--- a/lib/stripe/charges.ex
+++ b/lib/stripe/charges.ex
@@ -305,7 +305,7 @@ defmodule Stripe.Charges do
       {:ok, charge} = Stripe.Charges.refund_with_reversal("charge_id")
   """
   def refund_with_reversal(id) do
-    refund id, Stripe.config_or_env_key, %{reverse_transfer: true}
+    refund id, Stripe.config_or_env_key, %{reverse_transfer: true, refund_application_fee: true}
   end
 
 

--- a/lib/stripe/charges.ex
+++ b/lib/stripe/charges.ex
@@ -292,14 +292,28 @@ defmodule Stripe.Charges do
 
   """
   def refund(id) do
-    refund id, Stripe.config_or_env_key
+    refund id, Stripe.config_or_env_key, %{}
   end
+
+  @doc """
+  Refunds a charge and reverses transfer to connected accounts.
+
+  Return a `{:ok, charge}` tuple.
+
+  ## Examples
+
+      {:ok, charge} = Stripe.Charges.refund_with_reversal("charge_id")
+  """
+  def refund_with_reversal(id) do
+    refund id, Stripe.config_or_env_key, %{reverse_transfer: true}
+  end
+
 
   @doc """
   Refund a charge. Accepts Stripe API key.
 
   Refunds a charge completely.
-  
+
   Note: use `refund_partial` if you just want to perform a partial refund.
 
   Returns a `{:ok, charge}` tuple.
@@ -309,10 +323,11 @@ defmodule Stripe.Charges do
       {:ok, charge} = Stripe.Charges.refund("charge_id", "my_key")
 
   """
-  def refund(id, key) do
-    Stripe.make_request_with_key(:post, "#{@endpoint}/#{id}/refunds", key)
+  def refund(id, key, params) do
+    Stripe.make_request_with_key(:post, "#{@endpoint}/#{id}/refunds", key, params)
     |> Stripe.Util.handle_stripe_response
   end
+
 
   @doc """
   Partially refund a charge.

--- a/lib/stripe/transfers.ex
+++ b/lib/stripe/transfers.ex
@@ -1,0 +1,30 @@
+defmodule Stripe.Transfers do
+  @moduledoc """
+  Functions for working with Transfers within Stripe.
+
+  * update a transfer
+  * get a transfer
+
+  Stripe API Reference: https://stripe.com/docs/api#transfers
+  """
+
+  @endpoint "transfers"
+
+  def get(id) do
+    get(id, Stripe.config_or_env_key())
+  end
+
+  def get(id, key) do
+    Stripe.make_request_with_key(:get, "#{@endpoint}/#{id}", key)
+    |> Stripe.Util.handle_stripe_response()
+  end
+
+  def change(id, params) do
+    change(id, params, Stripe.config_or_env_key())
+  end
+
+  def change(id, params, key) do
+    Stripe.make_request_with_key(:post, "#{@endpoint}/#{id}", key, params)
+    |> Stripe.Util.handle_stripe_response()
+  end
+end


### PR DESCRIPTION
When working with Stripe Connect, it's nice to be able reverse transfers and application fees as well.

This adds the ability to do that manually and adds a convenience helper for doing a `refund_with_reversal`

I've been using this on a product for about 9 months now and thought it good to PR the change back.