### PR TITLE
Add upcoming invoice path

### DIFF
--- a/lib/stripe/invoice.ex
+++ b/lib/stripe/invoice.ex
@@ -92,4 +92,13 @@ defmodule Stripe.Invoice do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
+
+  @doc """
+  Retrieve an upcoming invoice.
+  """
+  @spec upcoming(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def upcoming(changes = %{customer: _customer}, opts \\ []) do
+    endpoint = @plural_endpoint <> "/upcoming"
+    Stripe.Request.retrieve(changes, endpoint, opts)
+  end
 end

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -20,8 +20,11 @@ defmodule Stripe.Request do
   end
 
   @spec retrieve(String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
-  def retrieve(endpoint, opts) do
-    %{}
+  def retrieve(endpoint, opts), do: retrieve(%{}, endpoint, opts)
+
+  @spec retrieve(map, String.t, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
+  def retrieve(changes, endpoint, opts) do
+    changes
     |> Stripe.request(:get, endpoint, %{}, opts)
     |> handle_result
   end


### PR DESCRIPTION
Hi,
I'm using upcoming invoices feature so I added the function to `lib/stripe/invoice.ex` as `upcoming`.
It is a `get` that requires some arguments in the body, I therefore changed the general `retrieve` function to accept a body map, keeping empty map as default.

Would you like to take this change in account ?
Cheers 

Ps : I'm not used to contributing in open source projects, so please let me know if I missed  something.
Pps: here is the api ref https://stripe.com/docs/api#upcoming_invoice