### PR TITLE
Add listing resources (#203)

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -186,4 +186,13 @@ defmodule Stripe.Account do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
+
+  @doc """
+  List all connected accounts.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -80,7 +80,8 @@ defmodule Stripe.Card do
   defp endpoint_for_owner(owner_type, owner_id) do
     case owner_type do
       :customer -> "customers/#{owner_id}/sources"
-      :recipient -> "recipients/#{owner_id}/cards"
+      :account -> "accounts/#{owner_id}/external_accounts"
+      :recipient -> "recipients/#{owner_id}/cards" # Deprecated
     end
   end
 
@@ -137,5 +138,15 @@ defmodule Stripe.Card do
   def delete(owner_type, owner_id, card_id, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
     Stripe.Request.delete(endpoint, %{}, opts)
+  end
+
+  @doc """
+  List all cards.
+  """
+  @spec list(source, String.t, map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(owner_type, owner_id, params \\ %{}, opts \\ []) do
+    endpoint = endpoint_for_owner(owner_type, owner_id)
+    params = Map.merge(params, %{"object" => "card"})
+    Stripe.Request.retrieve(params, endpoint, opts)
   end
 end

--- a/lib/stripe/charge.ex
+++ b/lib/stripe/charge.ex
@@ -103,4 +103,13 @@ defmodule Stripe.Charge do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.retrieve(endpoint, opts)
   end
+
+  @doc """
+  List all charges.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/coupon.ex
+++ b/lib/stripe/coupon.ex
@@ -79,4 +79,13 @@ defmodule Stripe.Coupon do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, %{}, opts)
   end
+
+  @doc """
+  List all coupons.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -99,4 +99,13 @@ defmodule Stripe.Customer do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, %{}, opts)
   end
+
+  @doc """
+  List all customers.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/event.ex
+++ b/lib/stripe/event.ex
@@ -29,4 +29,13 @@ defmodule Stripe.Event do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.retrieve(endpoint, opts)
   end
+
+  @doc """
+  List all events.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/external_account.ex
+++ b/lib/stripe/external_account.ex
@@ -88,4 +88,14 @@ defmodule Stripe.ExternalAccount do
     endpoint = endpoint(managed_account_id) <> "/" <> id
     Stripe.Request.delete(endpoint, %{}, opts)
   end
+
+  @doc """
+  List all external accounts.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts = [connect_account: managed_account_id]) do
+    endpoint = endpoint(managed_account_id)
+    params = Map.merge(params, %{"object" => "bank_account"})
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/file_upload.ex
+++ b/lib/stripe/file_upload.ex
@@ -38,4 +38,12 @@ defmodule Stripe.FileUpload do
     Stripe.Request.retrieve_file_upload(endpoint, opts)
   end
 
+  @doc """
+  List all file uploads.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/invoice.ex
+++ b/lib/stripe/invoice.ex
@@ -101,4 +101,13 @@ defmodule Stripe.Invoice do
     endpoint = @plural_endpoint <> "/upcoming"
     Stripe.Request.retrieve(changes, endpoint, opts)
   end
+
+  @doc """
+  List all invoices.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -79,4 +79,13 @@ defmodule Stripe.Plan do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, %{}, opts)
   end
+
+  @doc """
+  List all plans.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
 end

--- a/lib/stripe/refund.ex
+++ b/lib/stripe/refund.ex
@@ -58,5 +58,13 @@ defmodule Stripe.Refund do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @schema, @nullable_keys, opts)
   end
-end
 
+  @doc """
+  List all refunds.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(params, endpoint, opts)
+  end
+end

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -95,4 +95,13 @@ defmodule Stripe.Subscription do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, params, opts)
   end
+
+  @doc """
+  List all subscriptions.
+  """
+  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  def list(params \\ %{}, opts \\ []) do
+    endpoint = @plural_endpoint
+    Stripe.Request.retrieve(endpoint, opts)
+  end
 end


### PR DESCRIPTION
Add `list` functions to all Stripe objects (see #203). As per [official documentation](https://stripe.com/docs/api#list_charges),
```elixir
{:ok, charges} = Stripe.Charge.list()
```
will return a `Stripe.List` struct with a list of charges.

Pass optional arguments if they're supported.
```elixir
{:ok, charges} = Stripe.Charge.list(%{limit: 2, created: %{gt: 1497719598}})
```