### PR TITLE
Allow `prorate: false` on Subscription.update

### DIFF
--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -20,7 +20,7 @@ defmodule Stripe.Subscription do
     :id, :object,
     :application_fee_percent, :cancel_at_period_end, :canceled_at,
     :created, :current_period_end, :current_period_start, :customer,
-    :ended_at, :livemode, :metadata, :plan, :quantity, :source,
+    :ended_at, :livemode, :metadata, :plan, :prorate, :quantity, :source,
     :start, :status, :tax_percent, :trial_end, :trial_start
   ]
 
@@ -42,7 +42,7 @@ defmodule Stripe.Subscription do
     metadata: [:create, :retrieve, :update],
     object: [:retrieve],
     plan: [:create, :retrieve, :update],
-    prorate: [:create],
+    prorate: [:create, :update],
     quantity: [:create, :retrieve, :update],
     source: [:create, :update],
     start: [:retrieve],


### PR DESCRIPTION
Hi there,

Stripe allows you to send `prorate: false` in the post body on Subscription update so that they don't automatically prorate when a customer changes plans. We did this in stripity_stripe 1.6, and I'd like to keep doing it in 2.0.

Have tested and it works for me. Would love to know what you think. I call:
```ex
Stripe.Subscription.update(subscription_token, %{plan: plan_name, prorate: false}, [])
```

Thanks!