### PR TITLE
Fixed heading in markdown doc

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -4,7 +4,8 @@ defmodule Stripe do
     This module contains the Application that you can use to perform
     transactions on stripe API.
     
-    ### Configuring
+    **Configuring**
+    
     By default the STRIPE_SECRET_KEY environment variable is used to find
     your API key for Stripe. You can also manually set your API key by
     configuring the :stripity_stripe application. You can see the default

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -3,6 +3,7 @@ defmodule Stripe do
     A HTTP client for Stripe.
     This module contains the Application that you can use to perform
     transactions on stripe API.
+    
     ### Configuring
     By default the STRIPE_SECRET_KEY environment variable is used to find
     your API key for Stripe. You can also manually set your API key by


### PR DESCRIPTION
Hi, 

Read the documentation and saw that the configuration part of the first doc string is not rendered correctly. 

There's a missing newline/empty line before the heading Configuration.