### PR TITLE
Fixes for Account, Charge

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -23,7 +23,7 @@ defmodule Stripe.Account do
     :display_name, :email, :legal_entity, :external_accounts, :managed,
     :metadata, :statement_descriptor, :support_email, :support_phone,
     :support_url, :timezone, :tos_acceptance, :transfers_enabled,
-    :verification
+    :payouts_enabled, :verification
   ]
 
   @singular_endpoint "account"
@@ -122,6 +122,7 @@ defmodule Stripe.Account do
       ip: [:create, :retrieve, :update],
       user_agent: [:create, :retrieve, :update]
     },
+    payouts_enabled: [:retrieve],
     transfer_schedule: %{
       delay_days: [:create, :retrieve, :update],
       interval: [:create, :retrieve, :update],
@@ -144,7 +145,7 @@ defmodule Stripe.Account do
   def schema, do: @schema
 
   @nullable_keys [
-    :metadata, :transfer_statement_descriptor
+    :metadata
   ]
 
   @doc """
@@ -178,7 +179,6 @@ defmodule Stripe.Account do
 
   @doc """
   Update an account.
-
   Takes the `id` and a map of changes.
   """
   @spec update(binary, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}

--- a/lib/stripe/charge.ex
+++ b/lib/stripe/charge.ex
@@ -20,7 +20,7 @@ defmodule Stripe.Charge do
     :fraud_details, :invoice, :livemode, :metadata, :order, :outcome,
     :paid, :receipt_email, :receipt_number, :refunded, :refunds, :review,
     :shipping, :source, :source_transfer, :statement_descriptor, :status,
-    :transfer
+    :transfer, :transfer_group
   ]
 
   @plural_endpoint "charges"
@@ -75,7 +75,8 @@ defmodule Stripe.Charge do
     source_transfer: [:retrieve],
     statement_descriptor: [:create, :retrieve],
     status: [:retrieve],
-    transfer: [:retrieve]
+    transfer: [:retrieve],
+    transfer_group: [:retrieve, :create, :update]
   }
 
   @doc """


### PR DESCRIPTION
Stripe Accounts no longer take the `transfer_statement_descriptor`
parameter. I was getting errors because `nullable_fields` was
automatically submitting it on `Account.create/2`, resulting in an API
error:

```
Stripe.ApiErrorResponse{code: nil, message: "Received unknown parameter: transfer_statement_descriptor"}
```

`Stripe.Account` also needs to support the `payouts_enabled` parameter.
`Stripe.Charge` also needs to support the `transfer_group` parameter.