### PR TITLE
Add all Stripe objects as Stripe.Entity modules

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -47,6 +47,9 @@ defmodule Stripe do
   """
   use Application
 
+  @type id :: String.t
+  @type timestamp :: pos_integer
+
   @doc """
   Callback for the application
 
@@ -69,5 +72,4 @@ defmodule Stripe do
     opts = [strategy: :one_for_one, name: Stripe.Supervisor]
     Supervisor.start_link(children, opts)
   end
-
 end

--- a/lib/stripe/connect/account.ex
+++ b/lib/stripe/connect/account.ex
@@ -1,6 +1,6 @@
 defmodule Stripe.Account do
   @moduledoc """
-  Work with Stripe account objects.
+  Work with Stripe Connect account objects.
 
   You can:
 
@@ -13,16 +13,160 @@ defmodule Stripe.Account do
 
   Stripe API reference: https://stripe.com/docs/api#account
   """
+  use Stripe.Entity
 
-  @type t :: %__MODULE__{}
+
+
+  @type address :: %{
+                     city: String.t,
+                     country: String.t,
+                     line1: String.t,
+                     line2: String.t,
+                     postal_code: String.t,
+                     state: String.t
+                   }
+
+  @type address_jp :: %{
+                        city: String.t,
+                        country: String.t,
+                        line1: String.t,
+                        line2: String.t,
+                        postal_code: String.t,
+                        state: String.t,
+                        town: String.t
+                      }
+
+  @type verification :: %{
+                          details: String.t,
+                          details_code:
+                            :scan_corrupt | :scan_not_readable | :scan_failed_greyscale
+                            | :scan_not_uploaded | :scan_id_type_not_supported
+                            | :scan_id_country_not_supported | :scan_name_mismatch
+                            | :scan_failed_other | :failed_keyed_identity | :failed_other,
+                          document: Stripe.id | Stripe.FileUpload.t,
+                          status: :unverified | :pending | :verified
+                        }
+
+  @type additional_owner :: %{
+                              address: address,
+                              dob: %{
+                                day: pos_integer,
+                                month: pos_integer,
+                                year: pos_integer
+                              },
+                              first_name: String.t,
+                              last_name: String.t,
+                              maiden_name: String.t,
+                              verification: verification
+                            }
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               business_name: String.t,
+               business_url: String.t,
+               charges_enabled: boolean,
+               country: String.t,
+               debit_negative_balances: boolean,
+               decline_charge_on: %{
+                 avs_failure: boolean,
+                 cvc_failure: boolean
+               },
+               default_currency: String.t,
+               details_submitted: boolean,
+               display_name: String.t,
+               email: String.t,
+               external_accounts: Stripe.List.of(Stripe.BankAccount.t | Stripe.Card.t),
+               legal_entity: %{
+                 additional_owners: [additional_owner],
+                 address: address,
+                 address_kana: address_jp,
+                 address_kanji: address_jp,
+                 business_name: String.t,
+                 business_name_kana: String.t,
+                 business_name_kanji: String.t,
+                 business_tax_id_provided: boolean,
+                 business_vat_id_provided: boolean,
+                 dob: %{
+                   day: pos_integer,
+                   month: pos_integer,
+                   year: pos_integer
+                 },
+                 first_name: String.t,
+                 first_name_kanji: String.t,
+                 first_name_kana: String.t,
+                 gender: String.t,
+                 last_name: String.t,
+                 last_name_kana: String.t,
+                 last_name_kanji: String.t,
+                 maiden_name: String.t,
+                 personal_address: address,
+                 personal_address_kana: address_jp,
+                 personal_address_kanji: address_jp,
+                 personal_id_number_provided: boolean,
+                 phone_number: String.t,
+                 ssn_last_4_provided: String.t,
+                 tax_id_registar: String.t,
+                 type: :individual | :company,
+                 verification: verification
+               },
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               payout_schedule: %{
+                 delay_days: non_neg_integer,
+                 interval: :manual | :daily | :weekly | :monthly,
+                 monthly_anchor: non_neg_integer,
+                 weekly_anchor: String.t
+               },
+               payout_statement_descriptor: String.t,
+               payouts_enabled: boolean,
+               product_description: String.t,
+               statement_descriptor: String.t,
+               support_email: String.t,
+               support_phone: String.t,
+               timezone: String.t,
+               tos_acceptance: %{
+                 date: Stripe.timestamp,
+                 ip: String.t,
+                 user_agent: String.t
+               },
+               type: :standard | :express | :custom,
+               verification: %{
+                 disabled_reason:
+                   :"rejected.fraud" | :"rejected.terms_of_service" | :"rejected.listed"
+                   | :"rejected.other" | :fields_needed | :listed | :under_review | :other,
+                 due_by: Stripe.timestamp,
+                 fields_needed: [String.t]
+               }
+             }
 
   defstruct [
-    :id, :object,
-    :business_name, :business_primary_color, :business_url,
-    :charges_enabled, :country, :default_currency, :details_submitted,
-    :display_name, :email, :legal_entity, :external_accounts, :managed,
-    :metadata, :statement_descriptor, :support_email, :support_phone,
-    :support_url, :timezone, :tos_acceptance, :transfers_enabled,
+    :id,
+    :object,
+    :business_name,
+    :business_url,
+    :charges_enabled,
+    :country,
+    :debit_negative_balances,
+    :decline_charge_on,
+    :default_currency,
+    :details_submitted,
+    :display_name,
+    :email,
+    :legal_entity,
+    :external_accounts,
+    :metadata,
+    :payout_schedule,
+    :payout_statement_descriptor,
+    :payouts_enabled,
+    :product_description,
+    :statement_descriptor,
+    :support_email,
+    :support_phone,
+    :timezone,
+    :tos_acceptance,
+    :type,
     :verification
   ]
 
@@ -59,7 +203,7 @@ defmodule Stripe.Account do
   defp do_retrieve(endpoint, opts), do: Stripe.Request.retrieve(endpoint, opts)
 
   @doc """
-  Update an account.
+                                      Update an account.
 
   Takes the `id` and a map of changes.
   """

--- a/lib/stripe/connect/application_fee.ex
+++ b/lib/stripe/connect/application_fee.ex
@@ -1,0 +1,42 @@
+defmodule Stripe.ApplicationFee do
+  @moduledoc """
+  Work with Stripe Connect application fees.
+
+  Stripe API reference: https://stripe.com/docs/api#application_fees
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               account: Stripe.id | Stripe.Account.t,
+               amount: integer,
+               amount_refunded: integer,
+               application: Stripe.id | Stripe.Application.t,
+               balance_transaction: Stripe.id | Stripe.BalanceTransaction.t,
+               charge: Stripe.id | Stripe.Charge.t,
+               created: Stripe.timestamp,
+               currency: String.t,
+               livemode: boolean,
+               originating_transaction: Stripe.id | Stripe.Charge.t,
+               refunded: boolean,
+               refunds: Stripe.List.of(Stripe.FeeRefund.t)
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :account,
+    :amount,
+    :amount_refunded,
+    :application,
+    :balance_transaction,
+    :charge,
+    :created,
+    :currency,
+    :livemode,
+    :originating_transaction,
+    :refunded,
+    :refunds
+  ]
+end

--- a/lib/stripe/connect/country_spec.ex
+++ b/lib/stripe/connect/country_spec.ex
@@ -1,0 +1,39 @@
+defmodule Stripe.CountrySpec do
+  @moduledoc """
+  Work with the Stripe country specs API.
+
+  Stripe API reference: https://stripe.com/docs/api#country_specs
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               default_currency: String.t,
+               supported_bank_account_currencies: %{
+                 String.t => [String.t]
+               },
+               supported_payment_currencies: [String.t],
+               supported_payment_methods: [Stripe.Source.source_type | :stripe],
+               verification_fields: %{
+                 individual: %{
+                   minimum: [String.t],
+                   additional: [String.t]
+                 },
+                 company: %{
+                   minimum: [String.t],
+                   additional: [String.t]
+                 }
+               }
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :default_currency,
+    :supported_bank_account_currencies,
+    :supported_payment_currencies,
+    :supported_payment_methods,
+    :verification_fields
+  ]
+end

--- a/lib/stripe/connect/external_account.ex
+++ b/lib/stripe/connect/external_account.ex
@@ -18,18 +18,11 @@ defmodule Stripe.ExternalAccount do
 
   alias Stripe.Util
 
-  @type t :: %__MODULE__{}
-
-  defstruct [
-    :id, :object,
-    :account, :account_holder_name, :account_holder_type,
-    :bank_name, :country, :currency, :default_for_currency, :fingerprint,
-    :last4, :metadata, :routing_number, :status
-  ]
-
   defp endpoint(managed_account_id) do
     "accounts/#{managed_account_id}/external_accounts"
   end
+
+  @type t :: Stripe.BankAccount.t | Stripe.Card.t
 
   @doc """
   Create an external account.

--- a/lib/stripe/connect/fee_refund.ex
+++ b/lib/stripe/connect/fee_refund.ex
@@ -1,0 +1,33 @@
+defmodule Stripe.FeeRefund do
+  @moduledoc """
+  Work with Stripe Connect application fee refunds.
+
+  Stripe API reference: https://stripe.com/docs/api#fee_refunds
+
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: integer,
+               balance_transaction: Stripe.id | Stripe.BalanceTransaction.t,
+               created: Stripe.timestamp,
+               currency: String.t,
+               fee: Stripe.id | Stripe.ApplicationFee.t,
+               metadata: %{
+                 optional(String.t) => String.t
+               }
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :balance_transaction,
+    :created,
+    :currency,
+    :fee,
+    :metadata
+  ]
+end

--- a/lib/stripe/connect/login_link.ex
+++ b/lib/stripe/connect/login_link.ex
@@ -1,0 +1,19 @@
+defmodule Stripe.LoginLink do
+  @moduledoc """
+
+  """
+
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               object: String.t,
+               created: Stripe.timestamp,
+               url: String.t
+             }
+
+  defstruct [
+    :object,
+    :created,
+    :url
+  ]
+end

--- a/lib/stripe/connect/recipient.ex
+++ b/lib/stripe/connect/recipient.ex
@@ -1,0 +1,62 @@
+defmodule Stripe.Recipient do
+  @moduledoc """
+  Work with Stripe recipient objects.
+
+  Stripe API reference: https://stripe.com/docs/api#recipients
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               active_account: nil | %{
+                 id: Stripe.id,
+                 object: String.t,
+                 account: Stripe.id,
+                 account_holder_name: String.t,
+                 account_holder_type: :indivdual | :company,
+                 bank_name: String.t,
+                 country: String.t,
+                 currency: String.t,
+                 customer: Stripe.id,
+                 default_for_currency: boolean,
+                 fingerprint: String.t,
+                 last4: String.t,
+                 metadata: %{
+                   optional(String.t) => String.t
+                 },
+                 routing_number: String.t,
+                 status: :new | :validated | :verified | :verification_failed | :errored
+               },
+               cards: Stripe.List.of(Stripe.Card.t),
+               created: Stripe.timestamp,
+               default_card: Stripe.id | Stripe.Card.t,
+               description: String.t,
+               email: String.t,
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               migrated_to: Stripe.id | Stripe.Account.t,
+               name: String.t,
+               rolled_back_from: String.t,
+               type: String.t
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :active_account,
+    :cards,
+    :created,
+    :default_card,
+    :description,
+    :email,
+    :livemode,
+    :metadata,
+    :migrated_to,
+    :name,
+    :rolled_back_from,
+    :type
+  ]
+end

--- a/lib/stripe/connect/transfer.ex
+++ b/lib/stripe/connect/transfer.ex
@@ -1,0 +1,50 @@
+defmodule Stripe.Transfer do
+  @moduledoc """
+  Work with Stripe transfer objects.
+
+  Stripe API reference: https://stripe.com/docs/api#transfers
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: integer,
+               amount_reversed: integer,
+               balance_transaction: Stripe.id | Stripe.BalanceTransaction.t,
+               created: Stripe.timestamp,
+               currency: String.t,
+               description: String.t,
+               destination: Stripe.id | Stripe.Account.t,
+               destination_payment: String.t,
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               reversals: Stripe.List.of(Stripe.Reversal.t),
+               reversed: boolean,
+               source_transaction: Stripe.id | Stripe.Charge.t,
+               source_type: :card | :bank_account | :bitcoin_receiver | :alipay_account,
+               transfer_group: String.t,
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :amount_reversed,
+    :balance_transaction,
+    :created,
+    :currency,
+    :description,
+    :destination,
+    :destination_payment,
+    :livemode,
+    :metadata,
+    :reversals,
+    :reversed,
+    :source_transaction,
+    :source_type,
+    :transfer_group
+  ]
+end

--- a/lib/stripe/connect/transfer_reversal.ex
+++ b/lib/stripe/connect/transfer_reversal.ex
@@ -1,0 +1,34 @@
+defmodule Stripe.TransferReversal do
+  @moduledoc """
+  Work with Stripe transfer_reversal objects.
+
+  Stripe API reference: https://stripe.com/docs/api#transfer_reversal_object
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: integer,
+               balance_transaction: String.t | Stripe.BalanceTransaction.t,
+               created: Stripe.timestamp,
+               currency: String.t,
+               description: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               transfer: String.id | Stripe.Transfer.t
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :balance_transaction,
+    :created,
+    :currency,
+    :description,
+    :metadata,
+    :transfer
+  ]
+end

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -18,6 +18,8 @@ defmodule Stripe.Converter do
     coupon invoice line_item plan subscription
   )
 
+  @no_convert_maps ~w(metadata supported_bank_account_currencies)
+
   @spec convert_value(any) :: any
   defp convert_value(%{"object" => object_name} = value) when is_binary(object_name) do
     case Enum.member?(@supported_objects, object_name) do
@@ -48,7 +50,7 @@ defmodule Stripe.Converter do
           string_key = to_string(key)
           converted_value =
             case string_key do
-              "metadata" -> Map.get(value, string_key)
+              string_key when string_key in @no_convert_maps -> Map.get(value, string_key)
               _ -> Map.get(value, string_key) |> convert_value()
             end
           Map.put(acc, key, converted_value)

--- a/lib/stripe/core_resources/balance.ex
+++ b/lib/stripe/core_resources/balance.ex
@@ -4,7 +4,6 @@ defmodule Stripe.Balance do
 
   You can:
   - [Retrieve the current balance](https://stripe.com/docs/api#retrieve_balance)
-
   """
   use Stripe.Entity
   import Stripe.Request
@@ -19,9 +18,10 @@ defmodule Stripe.Balance do
 
   @type t :: %__MODULE__{
                object: String.t,
-               available: [funds],
+               available: list(funds),
+               connect_reserved: list(funds),
                livemode: boolean,
-               pending: [funds]
+               pending: list(funds)
              }
 
   defstruct [:object, :available, :connect_reserved, :livemode, :pending]

--- a/lib/stripe/core_resources/balance_transaction.ex
+++ b/lib/stripe/core_resources/balance_transaction.ex
@@ -9,15 +9,18 @@ defmodule Stripe.BalanceTransaction do
   use Stripe.Entity
   import Stripe.Request
 
-  @type transaction_type :: :adjustment | :application_fee | :application_fee_refund | :charge
-  | :payment | :payment_failure_refund | :payment_refund | :refund | :transfer | :transfer_refund
-  | :payout | :payout_cancel | :payout_failure | :validation
+  @type transaction_type :: :adjustment | :application_fee |
+                            :application_fee_refund | :charge | :payment |
+                            :payment_failure_refund | :payment_refund |
+                            :refund | :transfer | :transfer_refund | :payout |
+                            :payout_cancel | :payout_failure | :validation |
+                            :stripe_fee
 
   @type fee :: %{
                  amount: integer,
                  application: String.t,
                  currency: String.t,
-                 description: String.t,
+                 description: String.t | nil,
                  type: :application_fee | :stripe_fee | :tax
                }
 
@@ -28,17 +31,30 @@ defmodule Stripe.BalanceTransaction do
                available_on: Stripe.timestamp,
                created: Stripe.timestamp,
                currency: String.t,
-               description: String.t,
+               description: String.t | nil,
                fee: integer,
-               fee_details: [fee],
+               fee_details: list(fee) | [],
                net: integer,
                source: Stripe.id | Stripe.Source.t,
                status: :available | :pending,
                type: transaction_type
              }
 
-  defstruct [:id, :object, :amount, :available_on, :created, :currency, :description, :fee,
-    :fee_details, :net, :source, :status, :type]
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :available_on,
+    :created,
+    :currency,
+    :description,
+    :fee,
+    :fee_details,
+    :net,
+    :source,
+    :status,
+    :type
+  ]
 
   from_json data do
     data
@@ -74,15 +90,15 @@ defmodule Stripe.BalanceTransaction do
   """
   @spec all(params, Stripe.options) :: {:ok, Stripe.List.of(t)} | {:error, Stripe.Error.t}
         when params: %{
-               available_on: Stripe.date_query,
-               created: Stripe.date_query,
-               currency: String.t,
-               ending_before: Stripe.id | Stripe.BalanceTransaction.t,
-               limit: 1..100,
-               payout: Stripe.id | Stripe.Payout.t,
-               source: Stripe.id | Stripe.Source.t,
-               starting_after: Stripe.id | Stripe.BalanceTransaction.t,
-               type: Stripe.BalanceTransaction.transaction_type
+               available_on: Stripe.date_query | nil,
+               created: Stripe.date_query | nil,
+               currency: String.t | nil,
+               ending_before: Stripe.id | Stripe.BalanceTransaction.t | nil,
+               limit: 1..100 | nil,
+               payout: Stripe.id | Stripe.Payout.t | nil,
+               source: Stripe.id | Stripe.Source.t | nil,
+               starting_after: Stripe.id | Stripe.BalanceTransaction.t | nil,
+               type: Stripe.BalanceTransaction.transaction_type | nil
              }
   def all(params \\ %{}, opts \\ []) do
     new_request(opts)

--- a/lib/stripe/core_resources/dispute.ex
+++ b/lib/stripe/core_resources/dispute.ex
@@ -1,0 +1,92 @@
+defmodule Stripe.Dispute do
+  @moduledoc """
+  Work with Stripe disputes.
+
+  Stripe API reference: https://stripe.com/docs/api#disputes
+  """
+  use Stripe.Entity
+
+  @type dispute_evidence :: %{
+                              access_activity_log: String.t,
+                              billing_address: String.t,
+                              cancellation_policy: Stripe.id | Stripe.FileUpload.t,
+                              cancellation_policy_disclosure: String.t,
+                              cancellation_rebuttal: String.t,
+                              customer_communication: Stripe.id | Stripe.FileUpload.t,
+                              customer_email_address: String.t,
+                              customer_name: String.t,
+                              customer_purchase_ip: String.t,
+                              customer_signature: Stripe.id | Stripe.FileUpload.t,
+                              duplicate_charge_documentation: Stripe.id | Stripe.FileUpload.t,
+                              duplicate_charge_explanation: String.t,
+                              duplicate_charge_id: Stripe.id,
+                              product_description: String.t,
+                              receipt: Stripe.id | Stripe.FileUpload.t,
+                              refund_policy: Stripe.id | Stripe.FileUpload.t,
+                              refund_policy_disclosure: String.t,
+                              refund_refusal_explanation: String.t,
+                              service_date: String.t,
+                              service_documentation: Stripe.id | Stripe.FileUpload.t,
+                              shipping_address: String.t,
+                              shipping_carrier: String.t,
+                              shipping_date: String.t,
+                              shipping_documentation: Stripe.id | Stripe.FileUpload.t,
+                              shipping_tracking_number: Stripe.id | Stripe.FileUpload.t,
+                              uncategorized_file: Stripe.id | Stripe.FileUpload.t,
+                              uncategorized_text: String.t
+                            }
+
+  @type evidence_details :: %{
+                              due_by: Stripe.timestamp,
+                              has_evidence: boolean,
+                              past_due: boolean,
+                              submission_count: integer
+                            }
+
+  @type dispute_reason :: :duplicate | :fraudulent | :subscription_canceled |
+                          :product_unacceptable | :product_not_received |
+                          :unrecognized | :credit_not_processed | :general |
+                          :incorrect_account_details | :insufficient_funds |
+                          :bank_cannot_process | :debit_not_authorized |
+                          :customer_initiated
+
+  @type dispute_status :: :warning_needs_response | :warning_under_review |
+                          :warning_closed | :needs_response | :under_review |
+                          :charge_refunded | :won | :lost
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: integer,
+               balance_transactions: [Stripe.BalanceTransaction.t],
+               charge: Stripe.id | Stripe.Charge.t,
+               created: Stripe.timestamp,
+               currency: String.t,
+               evidence: dispute_evidence,
+               evidence_details: evidence_details,
+               is_charge_refundable: boolean,
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               reason: dispute_reason,
+               status: dispute_status
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :balance_transactions,
+    :charge,
+    :created,
+    :currency,
+    :evidence,
+    :evidence_details,
+    :is_charge_refundable,
+    :livemode,
+    :metadata,
+    :reason,
+    :status
+  ]
+end

--- a/lib/stripe/core_resources/event.ex
+++ b/lib/stripe/core_resources/event.ex
@@ -10,13 +10,37 @@ defmodule Stripe.Event do
 
   Stripe API reference: https://stripe.com/docs/api#event
   """
+  use Stripe.Entity
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               api_version: String.t,
+               created: Stripe.timestamp,
+               data: %{
+                 object: map,
+                 previous_attributes: map
+               },
+               livemode: boolean,
+               pending_webhooks: non_neg_integer,
+               request: %{
+                 id: String.t,
+                 idempotency_key: String.t
+               },
+               type: String.t
+             }
 
   defstruct [
-    :id, :object,
-    :api_version, :created, :data, :livemode, :pending_webhooks,
-    :request, :type, :user_id
+    :id,
+    :object,
+    :api_version,
+    :created,
+    :data,
+    :livemode,
+    :pending_webhooks,
+    :request,
+    :type,
+    :user_id
   ]
 
   @plural_endpoint "events"

--- a/lib/stripe/core_resources/file_upload.ex
+++ b/lib/stripe/core_resources/file_upload.ex
@@ -9,12 +9,26 @@ defmodule Stripe.FileUpload do
 
   Stripe API reference: https://stripe.com/docs/api#file_uploads
   """
+  use Stripe.Entity
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               created: Stripe.timestamp,
+               purpose: :dispute_evidence | :identity_document | :business_logo,
+               size: integer,
+               type: :pdf | :jpg | :png,
+               url: String.t
+             }
 
   defstruct [
-    :id, :object,
-    :created, :purpose, :size, :type, :metadata
+    :id,
+    :object,
+    :created,
+    :purpose,
+    :size,
+    :type,
+    :url
   ]
 
   @plural_endpoint "files"

--- a/lib/stripe/core_resources/payout.ex
+++ b/lib/stripe/core_resources/payout.ex
@@ -1,0 +1,57 @@
+defmodule Stripe.Payout do
+  @moduledoc """
+  Work with Stripe payouts.
+
+  Stripe API reference: https://stripe.com/docs/api#payouts
+  """
+  use Stripe.Entity
+
+  @type failure_code :: :account_closed | :account_frozen |
+                        :bank_account_restricted | :bank_ownership_changed |
+                        :could_not_process | :debit_not_authorized |
+                        :insufficient_funds | :invalid_account_number |
+                        :invalid_currency | :no_account | :unsupported_card |
+                        atom
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: integer,
+               arrival_date: Stripe.timestamp,
+               balance_transaction: Stripe.id | Stripe.BalanceTransaction.t,
+               created: Stripe.timestamp,
+               currency: String.t,
+               description: String.t,
+               destination: Stripe.id | Stripe.Card.t | Stripe.BankAccount.t,
+               failure_balance_transaction: Stripe.id | Stripe.BalanceTransaction.t,
+               failure_code: failure_code,
+               failure_message: String.t,
+               livemode: boolean,
+               method: :standard | :instant,
+               source_type: :card | :bank_account | :bitcoin_receiver | :alipay_account,
+               statement_descriptor: String.t,
+               status: :paid | :pending | :in_transit | :canceled | :failed,
+               type: :bank_account | :card
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :arrival_date,
+    :balance_transaction,
+    :created,
+    :currency,
+    :description,
+    :destination,
+    :failure_balance_transaction,
+    :failure_code,
+    :failure_message,
+    :livemode,
+    :method,
+    :source_type,
+    :statement_descriptor,
+    :status,
+    :type
+  ]
+end

--- a/lib/stripe/core_resources/refund.ex
+++ b/lib/stripe/core_resources/refund.ex
@@ -57,15 +57,16 @@ defmodule Stripe.Refund do
 
   When you create a new refund, you must specify a charge to create it on.
 
-  Creating a new refund will refund a charge that has previously been created but not yet refunded.
-  Funds will be refunded to the credit or debit card that was originally charged.
+  Creating a new refund will refund a charge that has previously been created
+  but not yet refunded. Funds will be refunded to the credit or debit card
+  that was originally charged.
 
-  You can optionally refund only part of a charge. You can do so as many times as you wish until
-  the entire charge has been refunded.
+  You can optionally refund only part of a charge. You can do so as many times
+  as you wish until the entire charge has been refunded.
 
-  Once entirely refunded, a charge can't be refunded again. This method will return an error when
-  called on an already-refunded charge, or when trying to refund more money than is left on a
-  charge.
+  Once entirely refunded, a charge can't be refunded again. This method will
+  return an error when called on an already-refunded charge, or when trying to
+  refund more money than is left on a charge.
 
   See the [Stripe docs](https://stripe.com/docs/api#create_refund).
   """
@@ -108,8 +109,8 @@ defmodule Stripe.Refund do
   @doc """
   Update a refund.
 
-  Updates the specified refund by setting the values of the parameters passed. Any parameters not
-  provided will be left unchanged.
+  Updates the specified refund by setting the values of the parameters passed.
+  Any parameters not provided will be left unchanged.
 
   This request only accepts `:metadata` as an argument.
 
@@ -133,9 +134,10 @@ defmodule Stripe.Refund do
   @doc """
   List all refunds.
 
-  Returns a list of all refunds you’ve previously created. The refunds are returned in sorted order,
-  with the most recent refunds appearing first. For convenience, the 10 most recent refunds are
-  always available by default on the charge object.
+  Returns a list of all refunds you’ve previously created. The refunds are
+  returned in sorted order, with the most recent refunds appearing first. For
+  convenience, the 10 most recent refunds are always available by default on
+  the charge object.
 
   See the [Stripe docs](https://stripe.com/docs/api#list_refunds).
   """

--- a/lib/stripe/core_resources/token.ex
+++ b/lib/stripe/core_resources/token.ex
@@ -12,62 +12,45 @@ defmodule Stripe.Token do
 
   Stripe API reference: https://stripe.com/docs/api#token
 
-  Example:
-
-  ```
-  {
-    "id": "tok_189fqt2eZvKYlo2CTGBeg6Uq",
-    "object": "token",
-    "card": {
-      "id": "card_189fqt2eZvKYlo2CQoh5XpA3",
-      "object": "card",
-      "address_city": null,
-      "address_country": null,
-      "address_line1": null,
-      "address_line1_check": null,
-      "address_line2": null,
-      "address_state": null,
-      "address_zip": null,
-      "address_zip_check": null,
-      "brand": "Visa",
-      "country": "US",
-      "cvc_check": null,
-      "dynamic_last4": null,
-      "exp_month": 8,
-      "exp_year": 2017,
-      "funding": "credit",
-      "last4": "4242",
-      "metadata": {
-      },
-      "name": null,
-      "tokenization_method": null
-    },
-    "client_ip": null,
-    "created": 1462905903,
-    "livemode": false,
-    "type": "card",
-    "used": false
-  }
-  ```
   """
+  use Stripe.Entity
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               bank_account: Stripe.BankAccount.t,
+               card: Stripe.Card.t,
+               client_ip: String.t,
+               created: Stripe.timestamp,
+               livemode: boolean,
+               type: :card | :bank_account,
+               used: boolean
+             }
 
   defstruct [
-    :id, :object,
-    :card, :client_ip, :created, :livemode, :type, :used
+    :id,
+    :object,
+    :bank_account,
+    :card,
+    :client_ip,
+    :created,
+    :livemode,
+    :type,
+    :used
   ]
 
   @plural_endpoint "tokens"
 
   @doc """
-  Create a token for a Connect customer with a card belonging to the
-  platform customer.
+  Create a token for a Connect customer with a card belonging to the platform
+  customer.
 
-  You must pass in the account number for the Stripe Connect account
-  in `opts`.
+  You must pass in the account number for the Stripe Connect account in `opts`.
   """
-  @spec create_on_connect_account(String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec create_on_connect_account(String.t, String.t, Keyword.t) :: {:ok, t} | {
+    :error,
+    Stripe.api_error_struct
+  }
   def create_on_connect_account(customer_id, customer_card_id, opts = [connect_account: _]) do
     body = %{
       card: customer_card_id,
@@ -79,10 +62,12 @@ defmodule Stripe.Token do
   @doc """
   Create a token for a Connect customer using the default card.
 
-  You must pass in the account number for the Stripe Connect account
-  in `opts`.
+  You must pass in the account number for the Stripe Connect account in `opts`.
   """
-  @spec create_with_default_card(String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec create_with_default_card(String.t, Keyword.t) :: {:ok, t} | {
+    :error,
+    Stripe.api_error_struct
+  }
   def create_with_default_card(customer_id, opts \\ []) do
     body = %{
       customer: customer_id
@@ -93,9 +78,10 @@ defmodule Stripe.Token do
   @doc """
   Create a token.
 
-  WARNING : This function is mainly for testing purposes only, you should not use
-  it on a production server, unless you are able to transfer and store credit card
-  data on your server in a PCI compliance way.
+  WARNING: This function is mainly for testing purposes only, you should not
+  use it on a production server, unless you are able to transfer and store
+  credit card data on your server in a PCI compliant way.
+
   Use the Stripe.js library on the client device instead.
   """
   @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}

--- a/lib/stripe/entity.ex
+++ b/lib/stripe/entity.ex
@@ -4,19 +4,22 @@ defmodule Stripe.Entity do
 
   Intended for internal use within the library.
 
-  A Stripe Entity is just a struct, optionally containing some logic for transforming a raw result
-  from the Stripe API into a final struct. This is achieved through the use of the `from_json/2`
-  macro.
+  A Stripe Entity is just a struct, optionally containing some logic for
+  transforming a raw result from the Stripe API into a final struct. This is
+  achieved through the use of the `from_json/2` macro.
 
-  The list of objects which are recognised by the library on being received is currently static and
-  contained in `Stripe.Converter`. When a map containing the `"object"` key is received from the API
-  (even when nested inside another map), and the value of that field (for example, `"foo_widget"`)
-  is in the list of supported objects, the converter will expect `Stripe.FooWidget` to be present
-  and to implement this behaviour.
+  The list of objects which are recognised by the library upon receipt are
+  currently static and contained in `Stripe.Converter`.
 
-  To implement this behaviour, simply add `use Stripe.Entity` to the top of the entity module and
-  make sure it defines a struct. This will also enable the use of the `from_json/2` macro, which
-  allows for changes to the data received from Stripe before it is converted to a struct.
+  When a map containing the `"object"` key is received from the API (even when
+  nested inside another map), and the value of that field (for example,
+  `"foo_widget"`) is in the list of supported objects, the converter will
+  expect `Stripe.FooWidget` to be present and to implement this behaviour.
+
+  To implement this behaviour, simply add `use Stripe.Entity` to the top of
+  the entity module and make sure it defines a struct. This will also enable
+  the use of the `from_json/2` macro, which allows for changes to the data
+  received from Stripe before it is converted to a struct.
   """
 
   @doc false
@@ -35,22 +38,27 @@ defmodule Stripe.Entity do
   end
 
   @doc """
-  Specifies data transformation logic for data for this object received from Stripe.
+  Specifies logic that transforms data from Stripe to our Stripe object.
 
-  The Stripe API docs specify that
+  The Stripe API docs specify that:
 
-  > JSON is returned by all API responses, including errors, although our API libraries convert
-  > responses to appropriate language-specific objects.
+  > JSON is returned by all API responses, including errors, although our API
+  > libraries convert responses to appropriate language-specific objects.
 
-  To this end, sometimes it is desirable to make changes to the raw data received from the Stripe
-  API, to aid its conversion into an appropriate Elixir struct.
+  To this end, sometimes it is desirable to make changes to the raw data
+  received from the Stripe API, to aid its conversion into an appropriate
+  Elixir data struct.
 
-  One example is the convention of converting "enum" values (for example "status" values of
-  "succeeded" or "failed") into atoms instead of keeping them as strings.
+  One example is the convention of converting `"enum"` values (for example
+  `"status"` values of `"succeeded"` or `"failed"`) into atoms instead of
+  keeping them as strings.
 
-  This macro is used in modules implementing the `Stripe.Entity` behaviour in order to specify this
-  extra logic. Its use is optional, and the default is no transformation – the received JSON keys
-  are merely converted to atoms and cast to the struct defined by the module.
+  This macro is used in modules implementing the `Stripe.Entity` behaviour in
+  order to specify this extra logic.
+
+  Its use is optional, and the default is no transformation; i.e. the received
+  JSON keys are merely converted to atoms and cast to the struct defined by
+  the module.
 
   The macro is used like this:
 
@@ -62,17 +70,20 @@ defmodule Stripe.Entity do
   end
   ```
 
-  It takes a parameter name to which the data received from Stripe is bound, and a do block which
-  should return the transformed data. The transformation receives the JSON response from Stripe,
-  with all keys converted to atoms (apart from keys inside a metadata map, which remain binaries)
-  and should return a map which is ready to be cast to the struct the module defines.
+  It takes a parameter name to which the data received from Stripe is bound,
+  and a `do` block which should return the transformed data. The
+  transformation receives the JSON response from Stripe, with all keys
+  converted to atoms (apart from keys inside a metadata map, which remain
+  binaries) and should return a map which is ready to be cast to the struct
+  the module defines.
 
-  The helper `cast_*` functions defined in this module are automatically imported into the scope
-  of this macro.
+  The helper `cast_*` functions defined in this module are automatically
+  imported into the scope of this macro.
 
-  The helper functions are all `nil`/missing key-safe, meaning that they will not magically add
-  fields or error on fields which are missing or unset. Therefore, write the transformation assuming
-  all possible data is actually present.
+  The helper functions are all `nil`/missing key-safe, meaning that they will
+  not magically add fields or error on fields which are missing or unset. You
+  should therefore write your transformation assuming all possible data is
+  actually present.
   """
   defmacro from_json(param, do: block) do
     quote do
@@ -86,9 +97,10 @@ defmodule Stripe.Entity do
   @doc """
   Cast the value of the given key or keys to an atom.
 
-  Provide either a single atom key or a list of atom keys whose values should be converted from
-  binaries to atoms. Used commonly to convert "enum" values (ones which belong to a predefined set)
-  in Stripe responses, for example a `:status` field.
+  Provide either a single atom key or a list of atom keys whose values should
+  be converted from binaries to atoms. Used commonly to convert `"enum"` values
+  (values which belong to a predefined set) in Stripe responses, for example a
+  `:status` field.
 
   If a key is not set or the value is `nil`, no transformation occurs.
   """
@@ -105,11 +117,12 @@ defmodule Stripe.Entity do
   @doc """
   Applies the given function over a list present in the data.
 
-  Provide either a single atom key or a list of atom keys whose values are lists. Each element of
-  such a list will be mapped using the function passed in.
+  Provide either a single atom key or a list of atom keys whose values are
+  lists. Each element of such a list will be mapped using the function passed.
 
-  For example, if there is a field `:fee_details` which is a list of maps, each containing a `:type`
-  key whose value we want to cast to an atom, we write
+  For example, if there is a field `:fee_details` which is a list of maps,
+  each containing a `:type` key whose value we want to cast to an atom, then
+  we write:
 
   ```
   data
@@ -131,17 +144,19 @@ defmodule Stripe.Entity do
   @doc """
   Applies the given function to a field accessed via the path provided.
 
-  Provide a path (identical to that used by the `Access` protocol) to the field to be modified, and
-  a function to be applied to its value. For example, if the field `:fraud_details` contains a map
-  whose keys `:user_report` and `:stripe_report` we wish to convert to atoms, we write
+  Provide a path (identical to that used by the `Access` protocol) to the
+  field to be modified, and a function to be applied to its value. For
+  example, if the field `:fraud_details` contains a map whose keys are
+  `:user_report` and `:stripe_report` we wish to convert to atoms, then we
+  write:
 
   ```
   data
   |> cast_path([:fraud_details], &cast_to_atom(&1, [:user_report, :stripe_report]))
   ```
 
-  Unlike `Kernel.update_in/2`, if the path to the key does not exist, or if the value is `nil`,
-  no transformation occurs.
+  Unlike `Kernel.update_in/2`, if the path to the key does not exist, or if
+  the value is `nil`, then no transformation occurs.
   """
   @spec cast_path(map, [atom], (any -> any)) :: map
   def cast_path(%{} = data, path, fun) when is_function(fun) do

--- a/lib/stripe/payment_methods/bank_account.ex
+++ b/lib/stripe/payment_methods/bank_account.ex
@@ -1,0 +1,46 @@
+defmodule Stripe.BankAccount do
+  @moduledoc """
+  Work with Stripe bank account objects.
+
+  Stripe API reference: https://stripe.com/docs/api#bank_accounts
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               account: Stripe.id | Stripe.Account.t,
+               account_holder_name: String.t,
+               account_holder_type: :individual | :company,
+               bank_name: String.t,
+               country: String.t,
+               currency: String.t,
+               customer: Stripe.id | Stripe.Customer.t,
+               default_for_currency: boolean,
+               fingerprint: String.t,
+               last4: String.t,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               routing_number: String.t,
+               status: :new | :validated | :verified | :verification_failed | :errored
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :account,
+    :account_holder_name,
+    :account_holder_type,
+    :bank_name,
+    :country,
+    :currency,
+    :customer,
+    :default_for_currency,
+    :fingerprint,
+    :last4,
+    :metadata,
+    :routing_number,
+    :status
+  ]
+end

--- a/lib/stripe/payment_methods/card.ex
+++ b/lib/stripe/payment_methods/card.ex
@@ -14,23 +14,79 @@ defmodule Stripe.Card do
 
   The owner type is indicated by setting either the `recipient` or `customer`
   ```
+
+  Stripe API reference: https://stripe.com/docs/api#cards
   """
   use Stripe.Entity
 
   alias Stripe.Util
 
-  @type t :: %__MODULE__{}
+  @type check_result :: :pass | :fail | :unavailable | :unchecked
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               account: Stripe.id | Stripe.Account.t,
+               address_city: String.t,
+               address_country: String.t,
+               address_line1: String.t,
+               address_line1_check: check_result,
+               address_line2: String.t,
+               address_state: String.t,
+               address_zip: String.t,
+               address_zip_check: check_result,
+               available_payout_methods: [:standard | :instant],
+               brand: String.t,
+               country: String.t,
+               currency: String.t,
+               customer: Stripe.id | Stripe.Customer.t,
+               cvc_check: check_result,
+               default_for_currency: boolean,
+               dynamic_last4: String.t,
+               exp_month: integer,
+               exp_year: integer,
+               fingerprint: String.t,
+               funding: :credit | :debit | :prepaid | :unknown,
+               last4: String.t,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               name: String.t,
+               recipient: Stripe.id | Stripe.Recipient.t,
+               tokenization_method: :apple_pay | :android_pay | nil
+             }
   @type source :: :customer | :recipient | :account
   @sources [:customer, :recipient, :account]
   @type owner :: Stripe.Customer.t | Stripe.Account.t
 
   defstruct [
-    :id, :object,
-    :address_city, :address_country, :address_line1,
-    :address_line1_check, :address_line2, :address_state,
-    :address_zip, :address_zip_check, :brand, :country,
-    :customer, :cvc_check, :dynamic_last4, :exp_month, :exp_year,
-    :fingerprint, :funding, :last4, :metadata, :name, :recipient,
+    :id,
+    :object,
+    :account,
+    :address_city,
+    :address_country,
+    :address_line1,
+    :address_line1_check,
+    :address_line2,
+    :address_state,
+    :address_zip,
+    :address_zip_check,
+    :available_payout_methods,
+    :brand,
+    :country,
+    :currency,
+    :customer,
+    :cvc_check,
+    :default_for_currency,
+    :dynamic_last4,
+    :exp_month,
+    :exp_year,
+    :fingerprint,
+    :funding,
+    :last4,
+    :metadata,
+    :name,
+    :recipient,
     :tokenization_method
   ]
 
@@ -58,7 +114,10 @@ defmodule Stripe.Card do
   If you want to create a card with your server without a token, you
   can use the low-level API.
   """
-  @spec create(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec create(source, String.t, String.t, Keyword.t) :: {:ok, t} | {
+    :error,
+    Stripe.api_error_struct
+  }
   def create(owner_type, owner_id, token, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id)
 
@@ -79,7 +138,10 @@ defmodule Stripe.Card do
   @doc """
   Retrieve a card.
   """
-  @spec retrieve(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec retrieve(source, String.t, String.t, Keyword.t) :: {:ok, t} | {
+    :error,
+    Stripe.api_error_struct
+  }
   def retrieve(owner_type, owner_id, card_id, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
     Stripe.Request.retrieve(endpoint, opts)
@@ -90,7 +152,10 @@ defmodule Stripe.Card do
 
   Takes the `id` and a map of changes
   """
-  @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {
+    :error,
+    Stripe.api_error_struct
+  }
   def update(owner_type, owner_id, card_id, changes, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
     Stripe.Request.update(endpoint, changes, opts)
@@ -99,8 +164,11 @@ defmodule Stripe.Card do
   @doc """
   Delete a card.
   """
-  @spec delete(source, owner_or_id, card_or_id, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
-      when owner_or_id: owner | String.t, card_or_id: t | String.t
+  @spec delete(source, owner_or_id, card_or_id, Keyword.t) :: :ok | {
+    :error,
+    Stripe.api_error_struct
+  }
+        when owner_or_id: owner | String.t, card_or_id: t | String.t
   def delete(owner_type, owner, card, opts \\ []) when owner_type in @sources do
     owner_id = Util.normalize_id(owner)
     card_id = Util.normalize_id(card)
@@ -115,7 +183,10 @@ defmodule Stripe.Card do
   @doc """
   List all cards.
   """
-  @spec list(source, String.t, map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  @spec list(source, String.t, map, Keyword.t) :: {:ok, Stripe.List.t} | {
+    :error,
+    Stripe.api_error_struct
+  }
   def list(owner_type, owner_id, params \\ %{}, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id)
     params = Map.merge(params, %{"object" => "card"})

--- a/lib/stripe/payment_methods/source.ex
+++ b/lib/stripe/payment_methods/source.ex
@@ -1,4 +1,103 @@
 defmodule Stripe.Source do
+  @moduledoc """
+  Work with Stripe source objects.
 
-  @type source_type :: :card | :three_d_secure | :giropay | :sepa_debit | :ideal | :sofort | :bancontact
+  Stripe API reference: https://stripe.com/docs/api#sources
+  """
+  use Stripe.Entity
+
+  @type source_type :: :card | :three_d_secure | :giropay | :sepa_debit | :ideal | :sofort
+  | :bancontact | :alipay | :bitcoin
+
+  @type address :: %{
+                     city: String.t,
+                     country: String.t,
+                     line1: String.t,
+                     line2: String.t,
+                     postal_code: String.t,
+                     state: String.t
+                   }
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: integer,
+               client_secret: String.t,
+               code_verification: %{
+                 attempts_remaining: integer,
+                 status: :pending | :succeeded | :failed
+               },
+               created: Stripe.timestamp,
+               currency: String.t,
+               flow: :redirect | :receiver | :code_verification | :none,
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               owner: %{
+                 address: address,
+                 email: String.t,
+                 name: String.t,
+                 phone: String.t,
+                 verifired_address: address,
+                 verified_email: String.t,
+                 verified_name: String.t,
+                 verified_phone: String.t
+               },
+               receiver: %{
+                 address: String.t,
+                 amount_charged: integer,
+                 amount_received: integer,
+                 amount_returned: integer
+               },
+               redirect: %{
+                 failure_reason: :user_abort | :declined | :processing_error,
+                 return_url: String.t,
+                 status: :prending | :succeeded | :not_required | :failed,
+                 url: String.t
+               },
+               statement_descriptor: String.t,
+               status: :canceled | :chargeable | :consumed | :failed | :pending,
+               type: source_type,
+               usage: :reusable | :single_use,
+               card: map | nil,
+               three_d_secure: map | nil,
+               giropay: map | nil,
+               sepa_debit: map | nil,
+               ideal: map | nil,
+               sofort: map | nil,
+               bancontact: map | nil,
+               alipay: map | nil,
+               bitcoin: map | nil
+             }
+  # TODO: find out the inner structure of the type-specific fields
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :client_secret,
+    :code_verification,
+    :created,
+    :currency,
+    :flow,
+    :livemode,
+    :metadata,
+    :owner,
+    :receiver,
+    :redirect,
+    :statement_descriptor,
+    :status,
+    :type,
+    :usage,
+    :card,
+    :three_d_secure,
+    :giropay,
+    :sepa_debit,
+    :ideal,
+    :sofort,
+    :bancontact,
+    :alipay,
+    :bitcoin
+  ]
 end

--- a/lib/stripe/radar/review.ex
+++ b/lib/stripe/radar/review.ex
@@ -1,0 +1,28 @@
+defmodule Stripe.Review do
+  @moduledoc """
+  Work with Stripe review objects.
+
+  Stripe API reference: https://stripe.com/docs/api#reviews
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               charge: Stripe.id | Stripe.Charge.t,
+               created: Stripe.timestamp,
+               livemode: boolean,
+               open: boolean,
+               reason: :rule | :manual | :approved | :refunded | :refunded_as_fraud | :disputed
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :charge,
+    :created,
+    :livemode,
+    :open,
+    :reason
+  ]
+end

--- a/lib/stripe/relay/order.ex
+++ b/lib/stripe/relay/order.ex
@@ -1,0 +1,91 @@
+defmodule Stripe.Order do
+  @moduledoc """
+  Work with Stripe orders.
+
+  Stripe API reference: https://stripe.com/docs/api#orders
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: pos_integer,
+               amount_returned: non_neg_integer,
+               application: Stripe.id,
+               application_fee: non_neg_integer,
+               charge: Stripe.id | Stripe.Charge.t,
+               currency: String.t,
+               customer: Stripe.id | Stripe.Customer.t,
+               email: String.t,
+               external_coupon_code: String.t,
+               items: Stripe.List.of(Stripe.OrderItem.t),
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               returns: Stripe.List.of(Stripe.Return.t),
+               selected_shipping_method: String.t,
+               shipping: %{
+                 address: %{
+                   city: String.t,
+                   country: String.t,
+                   line1: String.t,
+                   line2: String.t,
+                   postal_code: String.t,
+                   state: String.t
+                 },
+                 carrier: String.t,
+                 name: String.t,
+                 phone: String.t,
+                 tracking_number: String.t
+               },
+               shipping_methods: [
+                 %{
+                   id: String.t,
+                   amount: pos_integer,
+                   currency: String.t,
+                   delivery_estimate: %{
+                     date: String.t,
+                     earliest: String.t,
+                     latest: String.t,
+                     type: :range | :exact
+                   },
+                   description: String.t,
+                 }
+               ],
+               status: :created | :paid | :canceled | :fulfilled | :returned,
+               status_transitions: %{
+                 canceled: Stripe.timestamp,
+                 fulfiled: Stripe.timestamp,
+                 paid: Stripe.timestamp,
+                 returned: Stripe.timestamp
+               },
+               updated: Stripe.timstamp,
+               upstream_id: String.t
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :amount_returned,
+    :application,
+    :application_fee,
+    :charge,
+    :currency,
+    :customer,
+    :email,
+    :external_coupon_code,
+    :items,
+    :livemode,
+    :metadata,
+    :returns,
+    :selected_shipping_method,
+    :shipping,
+    :shipping_methods,
+    :status,
+    :status_transitions,
+    :updated,
+    :upstream_id
+  ]
+end

--- a/lib/stripe/relay/order_item.ex
+++ b/lib/stripe/relay/order_item.ex
@@ -1,0 +1,28 @@
+defmodule Stripe.OrderItem do
+  @moduledoc """
+  Work with Stripe order items.
+
+  Stripe API reference: https://stripe.com/docs/api#order_items
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               object: String.t,
+               amount: pos_integer,
+               currency: String.t,
+               description: String.t,
+               parent: nil | Stripe.id | Stripe.SKU.t,
+               quantity: nil | pos_integer,
+               type: :sku | :tax | :shipping | :discount
+             }
+
+  defstruct [
+    :object,
+    :amount,
+    :currency,
+    :description,
+    :parent,
+    :quantity,
+    :type
+  ]
+end

--- a/lib/stripe/relay/order_return.ex
+++ b/lib/stripe/relay/order_return.ex
@@ -1,0 +1,32 @@
+defmodule Stripe.OrderReturn do
+  @moduledoc """
+  Work with Stripe order returns.
+
+  Stripe API reference: https://stripe.com/docs/api#order_return_object
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount: pos_integer,
+               created: Stripe.timestamp,
+               currency: String.t,
+               items: Stripe.List.of(Stripe.OrderItem.t),
+               livemode: boolean,
+               order: Stripe.id | Stripe.Order.t,
+               refund: Stripe.id | Stripe.Refund.t
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :created,
+    :currency,
+    :items,
+    :livemode,
+    :order,
+    :refund
+  ]
+end

--- a/lib/stripe/relay/product.ex
+++ b/lib/stripe/relay/product.ex
@@ -1,0 +1,57 @@
+defmodule Stripe.Product do
+  @moduledoc """
+  Work with Stripe products.
+
+  Stripe API reference: https://stripe.com/docs/api#products
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               active: boolean,
+               attributes: %{
+                 optional(String.t) => String.t
+               },
+               caption: String.t,
+               created: Stripe.timestamp,
+               deactivate_on: [Stripe.id],
+               description: String.t,
+               images: [String.t],
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               name: String.t,
+               package_dimensions: nil | %{
+                 height: float,
+                 length: float,
+                 weight: float,
+                 width: float
+               },
+               shippable: boolean,
+               skus: Stripe.List.of(Stripe.SKU.t),
+               updated: Stripe.timestamp,
+               url: String.t
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :active,
+    :attributes,
+    :caption,
+    :created,
+    :deactivate_on,
+    :description,
+    :images,
+    :livemode,
+    :metadata,
+    :name,
+    :package_dimensions,
+    :shippable,
+    :skus,
+    :updated,
+    :url
+  ]
+end

--- a/lib/stripe/relay/sku.ex
+++ b/lib/stripe/relay/sku.ex
@@ -1,0 +1,55 @@
+defmodule Stripe.SKU do
+  @moduledoc """
+  Work with Stripe SKU objects.
+
+  Stripe API reference: https://stripe.com/docs/api#sku_object
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               active: boolean,
+               attributes: %{
+                 optional(String.t) => String.t
+               },
+               created: Stripe.timestamp,
+               currency: String.t,
+               image: String.t,
+               inventory: %{
+                 quantity: nil | non_neg_integer,
+                 type: :finite | :bucket | :infinite,
+                 value: nil | :in_stock | :limited | :out_of_stock
+               },
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               package_dimensions: nil | %{
+                 height: float,
+                 length: float,
+                 weight: float,
+                 width: float
+               },
+               price: non_neg_integer,
+               product: Stripe.id | Stripe.Product.t,
+               updated: Stripe.timestamp
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :active,
+    :attributes,
+    :created,
+    :currency,
+    :image,
+    :inventory,
+    :livemode,
+    :metadata,
+    :package_dimensions,
+    :price,
+    :product,
+    :updated
+  ]
+end

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -2,16 +2,17 @@ defmodule Stripe.Request do
   @moduledoc """
   A module for working with requests to the Stripe API.
 
-  Requests are composed in a functional manner. The request does not happen until it is configured
-  and passed to `make_request/1`.
+  Requests are composed in a functional manner. The request does not happen
+  until it is configured and passed to `make_request/1`.
 
-  Currently encompasses only requests to the normal Stripe API, the OAuth endpoint is not yet
-  supported.
+  Currently encompasses only requests to the normal Stripe API. The OAuth
+  endpoint is not yet supported.
 
-  Generally intended to be used internally, but can also be used by end-users to work around missing
-  endpoints (if any).
+  Generally intended to be used internally, but can also be used by end-users
+  to work around missing endpoints (if any).
 
-  At a minimum, a request must have the endpoint and method specified to be valid.
+  At a minimum, a request must have the endpoint and method specified to be
+  valid.
   """
   alias Stripe.{API, Request, Converter}
 
@@ -42,12 +43,13 @@ defmodule Stripe.Request do
   @doc """
   Specifies an endpoint for the request.
 
-  The endpoint should not include the `v1` prefix or an initial slash, for example
-  `put_endpoint(request, "charges")`.
+  The endpoint should not include the `v1` prefix or an initial slash, for
+  example `put_endpoint(request, "charges")`.
 
-  The endpoint can be a binary or a function which takes the parameters of the query and returns
-  and endpoint. The function is not evaluated until just before the request is made so the actual
-  parameters can be specified after the endpoint.
+  The endpoint can be a binary or a function which takes the parameters of the
+  query and returns an endpoint. The function is not evaluated until just
+  before the request is made so the actual parameters can be specified after
+  the endpoint.
   """
   @spec put_endpoint(t, String.t | (map -> String.t)) :: t
   def put_endpoint(%Request{} = request, endpoint) do
@@ -57,8 +59,8 @@ defmodule Stripe.Request do
   @doc """
   Specifies a method to use for the request.
 
-  Accepts any of the standard HTTP methods as atoms, that is `:get`, `:post`, `:put`, `:patch` or
-  `:delete`.
+  Accepts any of the standard HTTP methods as atoms, that is `:get`, `:post`,
+  `:put`, `:patch` or `:delete`.
   """
   @spec put_method(t, Stripe.API.method) :: t
   def put_method(%Request{} = request, method) when method in [:get, :post, :put, :patch, :delete] do
@@ -68,10 +70,11 @@ defmodule Stripe.Request do
   @doc """
   Specifies the parameters to be used for the request.
 
-  If the request is a POST request, these are encoded in the request body. Otherwise, they are
-  encoded in the URL.
+  If the request is a POST request, these are encoded in the request body.
+  Otherwise, they are encoded in the URL.
 
-  Calling this function multiple times will merge, not replace, the params currently specified.
+  Calling this function multiple times will merge, not replace, the params
+  currently specified.
   """
   @spec put_params(t, map) :: t
   def put_params(%Request{params: params} = request, new_params) do
@@ -89,13 +92,15 @@ defmodule Stripe.Request do
   @doc """
   Specify that a given set of parameters should be cast to a simple ID.
 
-  Sometimes, it may be convenient to allow end-users to pass in structs (say, the card to charge)
-  but the API requires only the ID of the object. This function will ensure that before the request
-  is made, the parameters specified here will be cast to IDs – if the value of a parameter is a
-  struct with an `:id` field, the value of that field will replace the struct in the parameter list.
+  Sometimes, it may be convenient to allow end-users to pass in structs (say,
+  the card to charge) but the API requires only the ID of the object. This
+  function will ensure that before the request is made, the parameters
+  specified here will be cast to IDs – if the value of a parameter is a
+  struct with an `:id` field, the value of that field will replace the struct
+  in the parameter list.
 
-  If the function is called multiple times, the set of parameters to cast to ID is merged between
-  the multiple calls.
+  If the function is called multiple times, the set of parameters to cast to
+  ID is merged between the multiple calls.
   """
   @spec cast_to_id(t, [atom]) :: t
   def cast_to_id(%Request{cast_to_id: cast_to_id} = request, new_cast_to_id) do
@@ -105,8 +110,9 @@ defmodule Stripe.Request do
   @doc """
   Specify that a given path in the parameters should be cast to a simple ID.
 
-  Acts similar to `cast_to_id/2` but specifies only one parameter to be cast, by specifying its path
-  (as in the `Access` protocol). Used to cast nested objects to their IDs.
+  Acts similar to `cast_to_id/2` but specifies only one parameter to be cast,
+  by specifying its path (as in the `Access` protocol). Used to cast nested
+  objects to their IDs.
   """
   @spec cast_path_to_id(t, [atom]) :: t
   def cast_path_to_id(%Request{cast_to_id: cast_to_id} = request, new_cast_to_id) do
@@ -116,11 +122,11 @@ defmodule Stripe.Request do
   @doc ~S"""
   Normalise the argument to a simple Stripe ID.
 
-  Actively extracts the ID, given a struct with an `:id` field, or returns the binary if one is
-  passed in.
+  Actively extracts the ID, given a struct with an `:id` field, or returns the
+  binary if one is passed in.
 
-  Useful for eagerly getting the ID of an object passed in, for example when computing the endpoint
-  to use:
+  Useful for eagerly getting the ID of an object passed in, for example when
+  computing the endpoint to use:
 
   ```
   def capture(id, params, opts) do
@@ -175,6 +181,4 @@ defmodule Stripe.Request do
     {:error, Stripe.Error.new(source: :internal, code: :invalid_endpoint,
       message: "endpoint must be a string or a function from params to a string")}
   end
-
-
 end

--- a/lib/stripe/subscriptions/coupon.ex
+++ b/lib/stripe/subscriptions/coupon.ex
@@ -12,14 +12,44 @@ defmodule Stripe.Coupon do
 
   Stripe API reference: https://stripe.com/docs/api#coupons
   """
-
+  use Stripe.Entity
+  import Stripe.Request
   alias Stripe.Util
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount_off: pos_integer,
+               created: Stripe.timestamp,
+               currency: String.t,
+               duration: :forever | :once | :repeating,
+               duration_in_months: pos_integer | nil,
+               livemode: boolean,
+               max_redemptions: pos_integer,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               percent_off: pos_integer,
+               redeem_by: Stripe.timestamp,
+               times_redeemed: non_neg_integer,
+               valid: boolean
+             }
 
   defstruct [
-    :id, :object, :amount_off, :created, :currency, :duration, :duration_in_months,
-    :livemode, :max_redemptions, :metadata, :percent_off, :redeem_by, :times_redeemed, :valid
+    :id,
+    :object,
+    :amount_off,
+    :created,
+    :currency,
+    :duration,
+    :duration_in_months,
+    :livemode,
+    :max_redemptions,
+    :metadata,
+    :percent_off,
+    :redeem_by,
+    :times_redeemed,
+    :valid
   ]
 
   @plural_endpoint "coupons"
@@ -27,47 +57,86 @@ defmodule Stripe.Coupon do
   @doc """
   Create a coupon.
   """
-  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, opts)
+  @spec create(params, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
+        when params: %{
+               id: String.t,
+               duration: :forever | :once | :repeating,
+               amount_off: pos_integer,
+               currency: String.t,
+               duration_in_months: pos_integer,
+               max_redemptions: pos_integer,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               percent_off: pos_integer,
+               redeem_by: Stripe.timestamp
+             }
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> make_request()
   end
 
   @doc """
   Retrieve a coupon.
   """
-  @spec retrieve(String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec retrieve(Stripe.id | t, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
   def retrieve(id, opts \\ []) do
-    endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, opts)
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
   end
 
   @doc """
-  Update a coupon.
+  Updates the metadata of a coupon. Other coupon details (currency, duration,
+  amount_off) are, by design, not editable.
 
   Takes the `id` and a map of changes.
   """
-  @spec update(String.t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def update(id, changes, opts \\ []) do
-    endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, opts)
+  @spec update(Stripe.id | t, params, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
+        when params: %{
+               metadata: %{
+                 optional(String.t) => String.t
+               }
+             }
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
   end
 
   @doc """
   Delete a coupon.
   """
-  @spec delete(t | String.t, list) :: :ok | {:error, Stripe.api_error_struct}
-  def delete(coupon, opts \\ []) do
-    id = Util.normalize_id(coupon)
-    endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.delete(endpoint, %{}, opts)
+  @spec delete(Stripe.id | t, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
+  def delete(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:delete)
+    |> make_request()
   end
 
   @doc """
   List all coupons.
   """
-  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  @spec list(params, Stripe.options) :: {:ok, Stripe.List.of(t)} | {:error, Stripe.Error.t}
+        when params: %{
+               created: Stripe.date_query,
+               ending_before: t | Stripe.id,
+               limit: 1..100,
+               starting_after: t | Stripe.id
+             }
   def list(params \\ %{}, opts \\ []) do
-    endpoint = @plural_endpoint
-    Stripe.Request.retrieve(params, endpoint, opts)
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:ending_before, :starting_after])
+    |> make_request()
   end
 end

--- a/lib/stripe/subscriptions/discount.ex
+++ b/lib/stripe/subscriptions/discount.ex
@@ -1,0 +1,26 @@
+defmodule Stripe.Discount do
+  @moduledoc """
+  Work with Stripe discounts.
+
+  Stripe API reference: https://stripe.com/docs/api#discounts
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               object: String.t,
+               coupon: Stripe.Coupon.t,
+               customer: Stripe.id,
+               end: Stripe.timestamp | nil,
+               start: Stripe.timestamp,
+               subscription: Stripe.id | nil
+             }
+
+  defstruct [
+    :object,
+    :coupon,
+    :customer,
+    :end,
+    :start,
+    :subscription
+  ]
+end

--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -12,20 +12,80 @@ defmodule Stripe.Invoice do
 
   Stripe API reference: https://stripe.com/docs/api#invoice
   """
-
+  use Stripe.Entity
+  import Stripe.Request
   alias Stripe.Util
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               amount_due: integer,
+               application_fee: integer,
+               attempt_count: non_neg_integer,
+               attempted: boolean,
+               charge: Stripe.id | Stripe.Charge.t,
+               closed: boolean,
+               currency: String.t,
+               customer: Stripe.id,
+               date: Stripe.timestamp,
+               description: String.t,
+               discount: Stripe.Discount.t,
+               ending_balance: integer,
+               forgiven: boolean,
+               lines: Stripe.List.of(Stripe.LineItem.t),
+               livemode: boolean,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               next_payment_attempt: Stripe.timestamp,
+               paid: boolean,
+               period_end: Stripe.timestamp,
+               period_start: Stripe.timestamp,
+               receipt_number: String.t,
+               starting_balance: integer,
+               statement_descriptor: String.t,
+               subscription: Stripe.id | Stripe.Subscription.t,
+               subscription_proration_date: Stripe.timestamp,
+               subtotal: integer,
+               tax: integer | nil,
+               tax_percent: integer | nil,
+               total: integer,
+               webhooks_delivered_at: Stripe.timestamp,
+             }
 
   defstruct [
-    :id, :object,
-    :amount_due, :application_fee, :attempt_count, :attempted,
-    :charge, :closed, :currency, :customer, :date, :description, :discount,
-    :ending_balance, :forgiven, :lines, :livemode, :metadata,
-    :next_payment_attempt, :paid, :period_end, :period_start,
-    :receipt_number, :starting_balance, :statement_descriptor,
-    :subscription, :subscription_proration_date, :subtotal, :tax,
-    :tax_percent, :total, :webhooks_delivered_at
+    :id,
+    :object,
+    :amount_due,
+    :application_fee,
+    :attempt_count,
+    :attempted,
+    :charge,
+    :closed,
+    :currency,
+    :customer,
+    :date,
+    :description,
+    :discount,
+    :ending_balance,
+    :forgiven,
+    :lines,
+    :livemode,
+    :metadata,
+    :next_payment_attempt,
+    :paid,
+    :period_end,
+    :period_start,
+    :receipt_number,
+    :starting_balance,
+    :statement_descriptor,
+    :subscription,
+    :subscription_proration_date,
+    :subtotal,
+    :tax,
+    :tax_percent,
+    :total,
+    :webhooks_delivered_at
   ]
 
   @plural_endpoint "invoices"
@@ -33,18 +93,35 @@ defmodule Stripe.Invoice do
   @doc """
   Create an invoice.
   """
-  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def create(changes, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, changes, opts)
+  @spec create(params, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
+        when params: %{
+               application_fee: integer,
+               description: String.t,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               statement_descriptor: String.t,
+               subscription: Stripe.id | Stripe.Subscription.t,
+               tax_percent: integer | nil
+             }
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> cast_to_id([:subscription])
+    |> make_request()
   end
 
   @doc """
   Retrieve an invoice.
   """
-  @spec retrieve(String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  @spec retrieve(Stripe.id | t, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
   def retrieve(id, opts \\ []) do
-    endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, opts)
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
   end
 
   @doc """
@@ -52,10 +129,24 @@ defmodule Stripe.Invoice do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(String.t, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def update(id, changes, opts \\ []) do
-    endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, opts)
+  @spec update(Stripe.id | t, params, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
+        when params: %{
+               application_fee: integer,
+               closed: boolean,
+               description: String.t,
+               forgiven: true,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               statement_descriptor: String.t,
+               tax_percent: integer | nil
+             }
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
   end
 
   @doc """
@@ -70,19 +161,37 @@ defmodule Stripe.Invoice do
   @doc """
   List all invoices.
   """
-  @spec list(map, Keyword.t) :: {:ok, Stripe.List.t} | {:error, Stripe.api_error_struct}
+  @spec list(params, Stripe.options) :: {:ok, Stripe.List.of(t)} | {:error, Stripe.Error.t}
+        when params: %{
+               customer: Stripe.Customer.t | Stripe.id,
+               date: Stripe.date_query,
+               ending_before: t | Stripe.id,
+               limit: 1..100,
+               starting_after: t | Stripe.id,
+               subscription: Stripe.Subscription.t | Stripe.id
+             }
   def list(params \\ %{}, opts \\ []) do
-    endpoint = @plural_endpoint
-    Stripe.Request.retrieve(params, endpoint, opts)
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:customer, :ending_before, :starting_after, :subscription])
+    |> make_request()
   end
 
   @doc """
   Pay an invoice.
   """
-  @spec pay(t | String.t, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
-  def pay(invoice, params \\ %{}, opts \\ []) do
-    id = Util.normalize_id(invoice)
-    endpoint = @plural_endpoint <> "/" <> id <> "/pay"
-    Stripe.Request.create(endpoint, params, opts)
+  @spec pay(Stripe.id | t, params, Stripe.options) :: {:ok, t} | {:error, Stripe.Error.t}
+        when params: %{
+               source: Stripe.id | Stripe.Source.t
+             }
+  def pay(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}/pay")
+    |> put_method(:post)
+    |> put_params(params)
+    |> cast_to_id([:source])
+    |> make_request()
   end
 end

--- a/lib/stripe/subscriptions/invoiceitem.ex
+++ b/lib/stripe/subscriptions/invoiceitem.ex
@@ -1,8 +1,11 @@
-defmodule Stripe.LineItem do
+defmodule Stripe.Invoiceitem do
   @moduledoc """
-  Work with Stripe (invoice) line item objects.
+  Work with Stripe invoiceitem objects.
 
-  Stripe API reference: https://stripe.com/docs/api/ruby#invoice_line_item_object
+  Stripe API reference: https://stripe.com/docs/api#invoiceitems
+
+  Note: this module is named `Invoiceitem` and not `InvoiceItem` on purpose, to
+  match the Stripe terminology of `invoiceitem`.
   """
   use Stripe.Entity
 
@@ -11,8 +14,11 @@ defmodule Stripe.LineItem do
                object: String.t,
                amount: integer,
                currency: String.t,
+               customer: Stripe.id | Stripe.Customer.t,
+               date: Stripe.timestamp,
                description: String.t,
                discountable: boolean,
+               invoice: Stripe.id | Stripe.Invoice.t,
                livemode: boolean,
                metadata: %{
                  optional(String.t) => String.t
@@ -24,9 +30,8 @@ defmodule Stripe.LineItem do
                plan: Stripe.Plan.t | nil,
                proration: boolean,
                quantity: integer,
-               subscription: Stripe.id | nil,
-               subscription_item: Stripe.id | nil,
-               type: :invoiceitem | :subscription
+               subscription: Stripe.id | Stripe.Subscription.t | nil,
+               subscription_item: Stripe.id | Stripe.SubscriptionItem.t | nil
              }
 
   defstruct [
@@ -34,8 +39,11 @@ defmodule Stripe.LineItem do
     :object,
     :amount,
     :currency,
+    :customer,
+    :date,
     :description,
     :discountable,
+    :invoice,
     :livemode,
     :metadata,
     :period,
@@ -43,12 +51,6 @@ defmodule Stripe.LineItem do
     :proration,
     :quantity,
     :subscription,
-    :subscription_item,
-    :type
+    :subscription_item
   ]
-
-  from_json data do
-    data
-    |> cast_to_atom([:type])
-  end
 end

--- a/lib/stripe/subscriptions/subscription_item.ex
+++ b/lib/stripe/subscriptions/subscription_item.ex
@@ -1,0 +1,28 @@
+defmodule Stripe.SubscriptionItem do
+  @moduledoc """
+  Work with Stripe subscription item objects.
+
+  Stripe API reference: https://stripe.com/docs/api#subscription_items
+  """
+  use Stripe.Entity
+
+  @type t :: %__MODULE__{
+               id: Stripe.id,
+               object: String.t,
+               created: Stripe.timestamp,
+               metadata: %{
+                 optional(String.t) => String.t
+               },
+               plan: Stripe.Plan.t,
+               quantity: non_neg_integer
+             }
+
+  defstruct [
+    :id,
+    :object,
+    :created,
+    :metadata,
+    :plan,
+    :quantity
+  ]
+end

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Stripe.Mixfile do
   defp deps do
     [
       {:bypass, "~> 0.5", only: :test},
-      {:dialyxir, "~> 0.4", only: [:dev], runtime: false},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.14", only: :dev},
       {:excoveralls, "~> 0.5", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
-  "dialyxir": {:hex, :dialyxir, "0.4.1", "236056d6acd25f740f336756c0f3b5dd6e2f0156074bc15f3b779aeee15390c8", [:mix], []},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], [], "hexpm"},
   "erlexec": {:hex, :erlexec, "1.7.1", "6ddbd40fa202084ed0bdaf95a50c334acaa5644ae213b903cd4094a78ae79734", [], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [repo: "hexpm", hex: :earmark, optional: false]}], "hexpm"},

--- a/test/stripe/core_resources/customer_test.exs
+++ b/test/stripe/core_resources/customer_test.exs
@@ -32,7 +32,7 @@ defmodule Stripe.CustomerTest do
     assert_stripe_requested :post, "/v1/customers/cus_123"
   end
 
-  test "is deletable" do
+  test "is deleteable" do
     {:ok, customer} = Stripe.Customer.retrieve("cus_123")
     assert {:ok, %Stripe.Customer{}} = Stripe.Customer.delete(customer)
     assert_stripe_requested :delete, "/v1/customers/#{customer.id}"

--- a/test/stripe/subscriptions/coupon_test.exs
+++ b/test/stripe/subscriptions/coupon_test.exs
@@ -27,4 +27,9 @@ defmodule Stripe.CouponTest do
     assert {:ok, %Stripe.Coupon{}} = Stripe.Coupon.update("25OFF", %{metadata: %{key: "value"}})
     assert_stripe_requested :post, "/v1/coupons/25OFF"
   end
+
+  test "is deleteable" do
+    assert {:ok, %Stripe.Coupon{}} = Stripe.Coupon.delete("25OFF")
+    assert_stripe_requested :delete, "/v1/coupons/25OFF"
+  end
 end

--- a/test/stripe/subscriptions/subscription_test.exs
+++ b/test/stripe/subscriptions/subscription_test.exs
@@ -33,6 +33,8 @@ defmodule Stripe.SubscriptionTest do
 
     test "delete_discount/2 deletes a subscription's discount" do
       {:ok, subscription} = Stripe.Subscription.retrieve("sub_123")
-      assert {:ok, %Stripe.Subscription{discount: nil}} = Stripe.Subscription.delete_discount(subscription)
+      # For some reason, stripe-mock returns a coupon here for the discount
+      assert {:ok, %{deleted: true}} = Stripe.Subscription.delete_discount(subscription)
+      assert_stripe_requested :delete, "/v1/subscriptions/#{subscription.id}/discount"
     end
 end

--- a/test/support/stripe_case.ex
+++ b/test/support/stripe_case.ex
@@ -19,5 +19,4 @@ defmodule Stripe.StripeCase do
       import Stripe.StripeCase, only: [assert_stripe_requested: 2, assert_stripe_requested: 3, stripe_base_url: 0]
     end
   end
-
 end


### PR DESCRIPTION
This is preparation for further endpoints being added and tested. Given that we get errors if a Stripe object is received from the API but does not implement `Stripe.Entity`, a good foundation is to just add all the appropriate structs in one pass before we start adding endpoints for them.

This PR adds all Stripe objects from the API docs as `Stripe.Entity` modules / structs, along with typespecs.

#### CORE RESOURCES
- [x] Balance
- [x] Balance transaction
- [x] Charges
- [x] Customers
- [x] Disputes
- [x] Events
- [x] File Uploads
- [x] Payouts
- [x] Refunds
- [x] Tokens

#### PAYMENT METHODS
- [x] Bank Accounts
- [x] Cards
- [x] Sources

#### SUBSCRIPTIONS
- [x] Coupons
- [x] Discounts
- [x] Invoices
- [x] Invoice Items
- [x] Invoice line items
- [x] Plans
- [x] Subscriptions
- [x] Subscription Items

#### CONNECT
- [x] Account
- [x] Application Fee Refunds
- [x] Application Fees
- [x] Country Specs
- [x] External Accounts
- [x] Recipients
- [x] Transfers
- [x] Transfer Reversals

#### RADAR
- [x] Reviews

#### RELAY
- [x] Orders
- [x] Order Items
- [x] Products
- [x] Returns
- [x] SKUs