### PR TITLE
Clean up Balance and BalanceTransaction types

### DIFF
--- a/lib/stripe/core_resources/balance.ex
+++ b/lib/stripe/core_resources/balance.ex
@@ -9,22 +9,28 @@ defmodule Stripe.Balance do
   import Stripe.Request
 
   @type funds :: %{
-                   currency: String.t,
-                   amount: integer,
-                   source_types: %{
-                     Stripe.Source.source_type => integer
-                   }
-                 }
+    currency: String.t,
+    amount: integer,
+    source_types: %{
+      Stripe.Source.source_type => integer
+    }
+  }
 
   @type t :: %__MODULE__{
-               object: String.t,
-               available: list(funds),
-               connect_reserved: list(funds),
-               livemode: boolean,
-               pending: list(funds)
-             }
+    object: String.t,
+    available: list(funds),
+    connect_reserved: list(funds) | nil,
+    livemode: boolean,
+    pending: list(funds)
+  }
 
-  defstruct [:object, :available, :connect_reserved, :livemode, :pending]
+  defstruct [
+    :object,
+    :available,
+    :connect_reserved,
+    :livemode,
+    :pending
+  ]
 
   @endpoint "balance"
 

--- a/lib/stripe/core_resources/balance_transaction.ex
+++ b/lib/stripe/core_resources/balance_transaction.ex
@@ -16,29 +16,21 @@ defmodule Stripe.BalanceTransaction do
                             :payout_cancel | :payout_failure | :validation |
                             :stripe_fee
 
-  @type fee :: %{
-                 amount: integer,
-                 application: String.t,
-                 currency: String.t,
-                 description: String.t | nil,
-                 type: :application_fee | :stripe_fee | :tax
-               }
-
   @type t :: %__MODULE__{
-               id: Stripe.id,
-               object: String.t,
-               amount: integer,
-               available_on: Stripe.timestamp,
-               created: Stripe.timestamp,
-               currency: String.t,
-               description: String.t | nil,
-               fee: integer,
-               fee_details: list(fee) | [],
-               net: integer,
-               source: Stripe.id | Stripe.Source.t,
-               status: :available | :pending,
-               type: transaction_type
-             }
+    id: Stripe.id,
+    object: String.t,
+    amount: integer,
+    available_on: Stripe.timestamp,
+    created: Stripe.timestamp,
+    currency: String.t,
+    description: String.t | nil,
+    fee: integer,
+    fee_details: list(Stripe.Types.fee) | [],
+    net: integer,
+    source: Stripe.id | Stripe.Source.t | nil, # TODO: clarify these
+    status: :available | :pending,
+    type: transaction_type
+  }
 
   defstruct [
     :id,

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -12,6 +12,14 @@ defmodule Stripe.Types do
     state: String.t | nil
   }
 
+  @type fee :: %{
+    amount: integer,
+    application: String.t | nil,
+    currency: String.t,
+    description: String.t | nil,
+    type: :application_fee | :stripe_fee | :tax
+  }
+
   @type shipping :: %{
     address: Stripe.Types.address,
     carrier: String.t | nil,


### PR DESCRIPTION
`source` for `BalanceTransaction` looks like it can be:

```
            - "$ref": "#/components/schemas/bitcoin_transaction"
            - "$ref": "#/components/schemas/charge"
            - "$ref": "#/components/schemas/dispute"
            - "$ref": "#/components/schemas/fee_refund"
            - "$ref": "#/components/schemas/payout"
            - "$ref": "#/components/schemas/transfer"
            - "$ref": "#/components/schemas/transfer_recipient_transfer"
            - "$ref": "#/components/schemas/platform_fee"
            - "$ref": "#/components/schemas/refund"
            - "$ref": "#/components/schemas/reserve_transaction"
            - "$ref": "#/components/schemas/transfer_reversal"
            - "$ref": "#/components/schemas/connect_collection_transfer"
            - "$ref": "#/components/schemas/topup"
```

I vote leave it for now and follow the `TODO` later.