### PR TITLE
Clean up Token, BankAccount, Card, Source types

### DIFF
--- a/lib/stripe/core_resources/token.ex
+++ b/lib/stripe/core_resources/token.ex
@@ -48,11 +48,11 @@ defmodule Stripe.Token do
     exp_month: integer,
     exp_year: integer,
     fingerprint: String.t | nil,
-    funding: :credit | :debit | :prepaid | :unknown,
+    funding: Stripe.Card.funding,
     last4: String.t,
     metadata: Stripe.Types.metadata,
     name: String.t | nil,
-    tokenization_method: :apple_pay | :android_pay | nil
+    tokenization_method: Stripe.Card.tokenization_method | nil
   }
 
   @type t :: %__MODULE__{

--- a/lib/stripe/core_resources/token.ex
+++ b/lib/stripe/core_resources/token.ex
@@ -19,14 +19,14 @@ defmodule Stripe.Token do
     id: Stripe.id,
     object: String.t,
     account_holder_name: String.t | nil,
-    account_holder_type: :individual | :company | nil,
+    account_holder_type: Stripe.BankAccount.account_holder_type | nil,
     bank_name: String.t | nil,
     country: String.t,
     currency: String.t,
     fingerprint: String.t | nil,
     last4: String.t,
     routing_number: String.t | nil,
-    status: :new | :validated | :verified | :verification_failed | :errored
+    status: Stripe.BankAccount.status
   }
 
   @type token_card :: %{

--- a/lib/stripe/core_resources/token.ex
+++ b/lib/stripe/core_resources/token.ex
@@ -15,17 +15,57 @@ defmodule Stripe.Token do
   """
   use Stripe.Entity
 
+  @type token_bank_account :: %{
+    id: Stripe.id,
+    object: String.t,
+    account_holder_name: String.t | nil,
+    account_holder_type: :individual | :company | nil,
+    bank_name: String.t | nil,
+    country: String.t,
+    currency: String.t,
+    fingerprint: String.t | nil,
+    last4: String.t,
+    routing_number: String.t | nil,
+    status: :new | :validated | :verified | :verification_failed | :errored
+  }
+
+  @type token_card :: %{
+    id: Stripe.id,
+    object: String.t,
+    address_city: String.t | nil,
+    address_country: String.t | nil,
+    address_line1: String.t | nil,
+    address_line1_check: Stripe.Card.check_result | nil,
+    address_line2: String.t | nil,
+    address_state: String.t | nil,
+    address_zip: String.t | nil,
+    address_zip_check: Stripe.Card.check_result | nil,
+    brand: String.t,
+    country: String.t | nil,
+    currency: String.t,
+    cvc_check: Stripe.Card.check_result | nil,
+    dynamic_last4: String.t | nil,
+    exp_month: integer,
+    exp_year: integer,
+    fingerprint: String.t | nil,
+    funding: :credit | :debit | :prepaid | :unknown,
+    last4: String.t,
+    metadata: Stripe.Types.metadata,
+    name: String.t | nil,
+    tokenization_method: :apple_pay | :android_pay | nil
+  }
+
   @type t :: %__MODULE__{
-               id: Stripe.id,
-               object: String.t,
-               bank_account: Stripe.BankAccount.t,
-               card: Stripe.Card.t,
-               client_ip: String.t,
-               created: Stripe.timestamp,
-               livemode: boolean,
-               type: :card | :bank_account,
-               used: boolean
-             }
+    id: Stripe.id,
+    object: String.t,
+    bank_account: token_bank_account,
+    card: token_card,
+    client_ip: String.t | nil,
+    created: Stripe.timestamp,
+    livemode: boolean,
+    type: :card | :bank_account,
+    used: boolean
+  }
 
   defstruct [
     :id,

--- a/lib/stripe/payment_methods/bank_account.ex
+++ b/lib/stripe/payment_methods/bank_account.ex
@@ -6,25 +6,27 @@ defmodule Stripe.BankAccount do
   """
   use Stripe.Entity
 
+  @type account_holder_type :: :individual | :company
+
+  @type status :: :new | :validated | :verified | :verification_failed | :errored
+
   @type t :: %__MODULE__{
-               id: Stripe.id,
-               object: String.t,
-               account: Stripe.id | Stripe.Account.t,
-               account_holder_name: String.t,
-               account_holder_type: :individual | :company,
-               bank_name: String.t,
-               country: String.t,
-               currency: String.t,
-               customer: Stripe.id | Stripe.Customer.t,
-               default_for_currency: boolean,
-               fingerprint: String.t,
-               last4: String.t,
-               metadata: %{
-                 optional(String.t) => String.t
-               },
-               routing_number: String.t,
-               status: :new | :validated | :verified | :verification_failed | :errored
-             }
+    id: Stripe.id,
+    object: String.t,
+    account: Stripe.id | Stripe.Account.t | nil,
+    account_holder_name: String.t | nil,
+    account_holder_type: account_holder_type | nil,
+    bank_name: String.t | nil,
+    country: String.t,
+    currency: String.t,
+    customer: Stripe.id | Stripe.Customer.t | nil,
+    default_for_currency: boolean | nil,
+    fingerprint: String.t | nil,
+    last4: String.t,
+    metadata: Stripe.Types.metadata | nil,
+    routing_number: String.t | nil,
+    status: status
+  }
 
   defstruct [
     :id,

--- a/lib/stripe/payment_methods/card.ex
+++ b/lib/stripe/payment_methods/card.ex
@@ -23,38 +23,41 @@ defmodule Stripe.Card do
 
   @type check_result :: :pass | :fail | :unavailable | :unchecked
 
+  @type funding :: :credit | :debit | :prepaid | :unknown
+
+  @type tokenization_method :: :apple_pay | :android_pay
+
   @type t :: %__MODULE__{
-               id: Stripe.id,
-               object: String.t,
-               account: Stripe.id | Stripe.Account.t,
-               address_city: String.t,
-               address_country: String.t,
-               address_line1: String.t,
-               address_line1_check: check_result,
-               address_line2: String.t,
-               address_state: String.t,
-               address_zip: String.t,
-               address_zip_check: check_result,
-               available_payout_methods: [:standard | :instant],
-               brand: String.t,
-               country: String.t,
-               currency: String.t,
-               customer: Stripe.id | Stripe.Customer.t,
-               cvc_check: check_result,
-               default_for_currency: boolean,
-               dynamic_last4: String.t,
-               exp_month: integer,
-               exp_year: integer,
-               fingerprint: String.t,
-               funding: :credit | :debit | :prepaid | :unknown,
-               last4: String.t,
-               metadata: %{
-                 optional(String.t) => String.t
-               },
-               name: String.t,
-               recipient: Stripe.id | Stripe.Recipient.t,
-               tokenization_method: :apple_pay | :android_pay | nil
-             }
+    id: Stripe.id,
+    object: String.t,
+    account: Stripe.id | Stripe.Account.t | nil,
+    address_city: String.t | nil,
+    address_country: String.t | nil,
+    address_line1: String.t | nil,
+    address_line1_check: check_result | nil,
+    address_line2: String.t | nil,
+    address_state: String.t | nil,
+    address_zip: String.t | nil,
+    address_zip_check: check_result | nil,
+    available_payout_methods: [:standard | :instant] | nil,
+    brand: String.t,
+    country: String.t | nil,
+    currency: String.t | nil,
+    customer: Stripe.id | Stripe.Customer.t | nil,
+    cvc_check: check_result | nil,
+    default_for_currency: boolean | nil,
+    dynamic_last4: String.t | nil,
+    exp_month: integer,
+    exp_year: integer,
+    fingerprint: String.t | nil,
+    funding: funding,
+    last4: String.t,
+    metadata: Stripe.Types.metadata,
+    name: String.t | nil,
+    recipient: Stripe.id | Stripe.Recipient.t | nil,
+    tokenization_method: tokenization_method | nil
+  }
+
   @type source :: :customer | :recipient | :account
   @sources [:customer, :recipient, :account]
   @type owner :: Stripe.Customer.t | Stripe.Account.t

--- a/lib/stripe/payment_methods/source.ex
+++ b/lib/stripe/payment_methods/source.ex
@@ -6,98 +6,180 @@ defmodule Stripe.Source do
   """
   use Stripe.Entity
 
-  @type source_type :: :card | :three_d_secure | :giropay | :sepa_debit | :ideal | :sofort
-  | :bancontact | :alipay | :bitcoin
+  @type source_type :: :ach_credit_transfer | :alipay | :bancontact |
+                       :bitcoin | :card | :giropay | :ideal | :p24 |
+                       :sofort | :three_d_secure
 
-  @type address :: %{
-                     city: String.t,
-                     country: String.t,
-                     line1: String.t,
-                     line2: String.t,
-                     postal_code: String.t,
-                     state: String.t
-                   }
+  @type ach_credit_transfer :: %{
+    account_number: String.t | nil,
+    bank_name: String.t | nil,
+    fingerprint: String.t | nil,
+    routing_number: String.t | nil,
+    swift_code: String.t | nil
+  }
+
+  @type alipay :: %{
+    data_string: String.t | nil,
+    native_url: String.t | nil,
+    statement_descriptor: String.t | nil
+  }
+
+  @type bancontact :: %{
+    bank_code: String.t | nil,
+    bank_name: String.t | nil,
+    bic: String.t | nil,
+    preferred_language: String.t | nil,
+    statement_descriptor: String.t | nil
+  }
+
+  @type bitcoin :: %{
+    address: String.t | nil,
+    amount: String.t | nil,
+    amount_charged: String.t | nil,
+    amount_received: String.t | nil,
+    amount_returned: String.t | nil,
+    refund_address: String.t | nil,
+    uri: String.t | nil
+  }
+
+  @type card :: %{
+    address_line1_check: Stripe.Card.check_result | nil,
+    address_zip_check: Stripe.Card.check_result | nil,
+    brand: String.t | nil,
+    country: String.t | nil,
+    cvc_check: Stripe.Card.check_result | nil,
+    dynamic_last4: String.t | nil,
+    exp_month: integer | nil,
+    exp_year: integer | nil,
+    fingerprint: String.t,
+    funding: Stripe.Card.funding | nil,
+    last4: String.t | nil,
+    skip_validation: boolean,
+    three_d_secure: String.t,
+    tokenization_method: Stripe.Card.tokenization_method | nil
+  }
+
+  @type code_verification_flow :: %{
+    attempts_remaining: integer,
+    status: :pending | :succeeded | :failed
+  }
+
+  @type giropay :: %{
+    bank_code: String.t | nil,
+    bank_name: String.t | nil,
+    bic: String.t | nil,
+    statement_descriptor: String.t | nil
+  }
+
+  @type ideal :: %{
+    bank: String.t | nil,
+    bic: String.t | nil,
+    iban_last4: String.t | nil,
+    statement_descriptor: String.t | nil
+  }
+
+  @type owner :: %{
+    address: Stripe.Types.address | nil,
+    email: String.t | nil,
+    name: String.t | nil,
+    phone: String.t | nil,
+    verifired_address: Stripe.Types.address | nil,
+    verified_email: String.t | nil,
+    verified_name: String.t | nil,
+    verified_phone: String.t | nil
+  }
+
+  @type p24 :: %{
+    reference: String.t | nil
+  }
+
+  @type receiver_flow :: %{
+    address: String.t | nil,
+    amount_charged: integer,
+    amount_received: integer,
+    amount_returned: integer
+  }
+
+  @type redirect_flow :: %{
+    failure_reason: :user_abort | :declined | :processing_error | nil,
+    return_url: String.t,
+    status: :prending | :succeeded | :not_required | :failed,
+    url: String.t
+  }
+
+  @type sofort :: %{
+    bank_code: String.t | nil,
+    bank_name: String.t | nil,
+    bic: String.t | nil,
+    country: String.t | nil,
+    iban_last4: String.t | nil,
+    preferred_language: String.t | nil,
+    statement_descriptor: String.t | nil
+  }
+
+  @type three_d_secure :: %{
+    authenticated: boolean | nil,
+    card: String.t | nil,
+    customer: String.t | nil
+  }
 
   @type t :: %__MODULE__{
-               id: Stripe.id,
-               object: String.t,
-               amount: integer,
-               client_secret: String.t,
-               code_verification: %{
-                 attempts_remaining: integer,
-                 status: :pending | :succeeded | :failed
-               },
-               created: Stripe.timestamp,
-               currency: String.t,
-               flow: :redirect | :receiver | :code_verification | :none,
-               livemode: boolean,
-               metadata: %{
-                 optional(String.t) => String.t
-               },
-               owner: %{
-                 address: address,
-                 email: String.t,
-                 name: String.t,
-                 phone: String.t,
-                 verifired_address: address,
-                 verified_email: String.t,
-                 verified_name: String.t,
-                 verified_phone: String.t
-               },
-               receiver: %{
-                 address: String.t,
-                 amount_charged: integer,
-                 amount_received: integer,
-                 amount_returned: integer
-               },
-               redirect: %{
-                 failure_reason: :user_abort | :declined | :processing_error,
-                 return_url: String.t,
-                 status: :prending | :succeeded | :not_required | :failed,
-                 url: String.t
-               },
-               statement_descriptor: String.t,
-               status: :canceled | :chargeable | :consumed | :failed | :pending,
-               type: source_type,
-               usage: :reusable | :single_use,
-               card: map | nil,
-               three_d_secure: map | nil,
-               giropay: map | nil,
-               sepa_debit: map | nil,
-               ideal: map | nil,
-               sofort: map | nil,
-               bancontact: map | nil,
-               alipay: map | nil,
-               bitcoin: map | nil
-             }
-  # TODO: find out the inner structure of the type-specific fields
+    id: Stripe.id,
+    object: String.t,
+    ach_credit_transfer: ach_credit_transfer | nil,
+    alipay: alipay | nil,
+    amount: integer | nil,
+    bancontact: bancontact | nil,
+    bitcoin: bitcoin | nil,
+    card: card | nil,
+    client_secret: String.t,
+    code_verification: code_verification_flow | nil,
+    created: Stripe.timestamp,
+    currency: String.t | nil,
+    flow: :redirect | :receiver | :code_verification | :none,
+    giropay: giropay | nil,
+    ideal: ideal | nil,
+    livemode: boolean,
+    metadata: Stripe.Types.metadata,
+    owner: owner | nil,
+    p24: p24 | nil,
+    receiver: receiver_flow | nil,
+    redirect: redirect_flow | nil,
+    sofort: sofort | nil,
+    statement_descriptor: String.t | nil,
+    status: :canceled | :chargeable | :consumed | :failed | :pending,
+    three_d_secure: three_d_secure | nil,
+    type: source_type,
+    usage: :reusable | :single_use | nil,
+  }
 
   defstruct [
     :id,
     :object,
+    :ach_credit_transfer,
+    :alipay,
     :amount,
+    :bancontact,
+    :bitcoin,
+    :card,
     :client_secret,
     :code_verification,
     :created,
     :currency,
     :flow,
+    :giropay,
+    :ideal,
     :livemode,
     :metadata,
     :owner,
+    :p24,
     :receiver,
     :redirect,
+    :sofort,
     :statement_descriptor,
     :status,
-    :type,
-    :usage,
-    :card,
     :three_d_secure,
-    :giropay,
-    :sepa_debit,
-    :ideal,
-    :sofort,
-    :bancontact,
-    :alipay,
-    :bitcoin
+    :type,
+    :usage
   ]
 end

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -20,6 +20,10 @@ defmodule Stripe.Types do
     type: :application_fee | :stripe_fee | :tax
   }
 
+  @type metadata :: %{
+    optional(String.t) => String.t
+  }
+
   @type shipping :: %{
     address: Stripe.Types.address,
     carrier: String.t | nil,


### PR DESCRIPTION
Note that this adds a `token_bank_account` and `token_card` as the OpenAPI specs for Stripe indicate that these have different schemas from our own `Stripe.BankAccount` and `Stripe.Card`.

I've also now added `Stripe.Types.metadata` so we can stop repeating that key.

Also moved some of the types like `account_holder_type`, `status`, `tokenization_method`, etc. into the relevant entities such as `Stripe.BankAccount.status`.

This also expands on the `Source` types and their inner structure.