### PR TITLE
Add ExternalAccount endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,6 @@ before_install:
 script: mix coveralls.travis
 after_script:
   - mix inch.report
+notifications:
+  email:
+    on_success: never

--- a/lib/stripe/connect/account.ex
+++ b/lib/stripe/connect/account.ex
@@ -185,11 +185,7 @@ defmodule Stripe.Account do
           decline_charge_on: decline_charge_on | nil,
           default_currency: String.t() | nil,
           email: String.t() | nil,
-          external_account:
-            Stripe.ExternalAccount.create_params_for_bank_account()
-            | Stripe.ExternalAccount.create_params_for_card()
-            | String.t()
-            | nil,
+          external_account: String.t() | nil,
           legal_entity: legal_entity,
           metadata: Stripe.Types.metadata() | nil,
           payout_schedule: Stripe.Types.transfer_schedule() | nil,
@@ -253,11 +249,7 @@ defmodule Stripe.Account do
           decline_charge_on: decline_charge_on | nil,
           default_currency: String.t() | nil,
           email: String.t() | nil,
-          external_account:
-            Stripe.ExternalAccount.create_params_for_bank_account()
-            | Stripe.ExternalAccount.create_params_for_card()
-            | String.t()
-            | nil,
+          external_account: String.t() | nil,
           legal_entity: legal_entity,
           metadata: Stripe.Types.metadata() | nil,
           payout_schedule: Stripe.Types.transfer_schedule() | nil,

--- a/test/stripe/connect/external_account_test.exs
+++ b/test/stripe/connect/external_account_test.exs
@@ -1,0 +1,65 @@
+defmodule Stripe.ExternalAccountTest do
+  use Stripe.StripeCase, async: true
+
+  describe "create/2" do
+    test "creates a bank account for an account" do
+      {:ok, _} = Stripe.ExternalAccount.create(%{account: "acct_123", token: "tok_stripetestbank"})
+      assert_stripe_requested(:post, "/v1/accounts/acct_123/external_accounts")
+    end
+
+    test "creates a card for an account" do
+      {:ok, _} = Stripe.ExternalAccount.create(%{account: "acct_123", token: "tok_amex"})
+      assert_stripe_requested(:post, "/v1/accounts/acct_123/external_accounts")
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a bank account" do
+      {:ok, _} = Stripe.ExternalAccount.retrieve("ba_123", %{account: "acct_123"})
+      assert_stripe_requested(:get, "/v1/accounts/acct_123/external_accounts/ba_123")
+    end
+
+    test "retrieves a card" do
+      {:ok, _} = Stripe.ExternalAccount.retrieve("card_123", %{account: "acct_123"})
+      assert_stripe_requested(:get, "/v1/accounts/acct_123/external_accounts/card_123")
+    end
+  end
+
+  describe "update/2" do
+    test "updates a bank account" do
+      {:ok, _} = Stripe.ExternalAccount.update("ba_123", %{account: "acct_123"})
+      assert_stripe_requested(:post, "/v1/accounts/acct_123/external_accounts/ba_123")
+    end
+
+    test "updates a card" do
+      {:ok, _} = Stripe.ExternalAccount.update("card_123", %{account: "acct_123"})
+      assert_stripe_requested(:post, "/v1/accounts/acct_123/external_accounts/card_123")
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a bank account" do
+      {:ok, _} = Stripe.ExternalAccount.delete("ba_123", %{account: "acct_123"})
+      assert_stripe_requested(:delete, "/v1/accounts/acct_123/external_accounts/ba_123")
+    end
+
+    test "deletes a card" do
+      {:ok, _} = Stripe.ExternalAccount.delete("card_123", %{account: "acct_123"})
+      assert_stripe_requested(:delete, "/v1/accounts/acct_123/external_accounts/card_123")
+    end
+  end
+
+  describe "list/3" do
+    test "lists all bank accounts for an account" do
+      {:ok, %Stripe.List{data: bank_accounts}} = Stripe.ExternalAccount.list(:bank_account, %{account: "acct_123"})
+      assert_stripe_requested(:get, "/v1/accounts/acct_123/external_accounts?object=bank_account")
+      assert is_list(bank_accounts)
+    end
+
+    test "lists all cards for an account" do
+      {:ok, %Stripe.List{data: cards}} = Stripe.ExternalAccount.list(:card, %{account: "acct_123"})
+      assert_stripe_requested(:get, "/v1/accounts/acct_123/external_accounts?object=card")
+      assert is_list(cards)
+    end
+  end
+end


### PR DESCRIPTION
- Removes the ability to send hashes for external accounts, taking inspiration from the Go library while still allowing this module to be used, e.g. in Go: `bankaccount.New(&stripe.BankAccountParams{AccountID: {ACCOUNT_ID}, Token: {TOKEN_ID}})`
- Supports `list` with a required `atom`