### PR TITLE
Add Ephemeral Key creation api (#262)

### DIFF
--- a/lib/stripe/ephemeral_key.ex
+++ b/lib/stripe/ephemeral_key.ex
@@ -1,0 +1,40 @@
+defmodule Stripe.EphemeralKey do
+  @moduledoc """
+  Work with Stripe EphemeralKey objects.
+
+  You can:
+
+  - Create a ephemeral key
+
+  Does not yet render lists or take options.
+  
+  Does not have an afficiol API docs endpoint, 
+  but is required for iOS and Android SDK functionality.
+  
+  Explained in
+  https://stripe.com/docs/mobile/ios/standard#prepare-your-api
+  https://stripe.com/docs/mobile/android/customer-information#prepare-your-api
+
+  Stripe API reference: https://stripe.com/docs/api#customer
+  """
+  defstruct [
+    :id, :object,
+    :created, :expires,
+    :secret, :associated_objects
+  ]
+
+  @type t :: %__MODULE__{}
+
+  @plural_endpoint "ephemeral_keys"
+
+  @schema %{
+    customer: [:create]
+  }
+  @doc """
+  Create an ephemeral key.
+  """
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
+  def create(changes, api_version, opts \\ []) do
+    Stripe.Request.create(@plural_endpoint, changes, @schema, opts, %{"Stripe-Version": api_version})
+  end
+end

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -2,11 +2,11 @@ defmodule Stripe.Request do
   alias Stripe.Changeset
   alias Stripe.Converter
 
-  @spec create(String.t, map, map, Keyword.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
-  def create(endpoint, changes, schema, opts) do
+  @spec create(String.t, map, map, Keyword.t, map) :: {:ok, map} | {:error, Stripe.api_error_struct}
+  def create(endpoint, changes, schema, opts, headers \\ %{}) do
     changes
     |> Changeset.cast(schema, :create)
-    |> Stripe.request(:post, endpoint, %{}, opts)
+    |> Stripe.request(:post, endpoint, headers, opts)
     |> handle_result
   end
 


### PR DESCRIPTION
* Add Ephemeral Key creation api

Merges in an addition from the alpha branch. 

This also introduces a non-breaking change to `Request.create` by adding an optional `headers` argument at the end. 

It's not a perfect way to introduce custom headers, but we don't have any other yet.