### PR TITLE
add the api-version to the header for backwards-compatibility

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -235,7 +235,8 @@ defmodule Stripe do
       "Accept-Encoding" => "gzip",
       "Content-Type" => "application/x-www-form-urlencoded",
       "Connection" => "keep-alive",
-      "User-Agent" => "Stripe/v1 stripity-stripe/#{@api_version}"
+      "User-Agent" => "Stripe/v1 stripity-stripe/#{@api_version}",
+      "Stripe-Version" => @api_version
     })
   end
 


### PR DESCRIPTION
Added the library's stated supported API version in requests to make certain endpoints to work (I created an account recently, and can't rely on "not upgrading" to maintain compatibility with this library).