### PR TITLE
Cleanup StripeCard - v2.0.0-beta.1

### DIFF
--- a/lib/stripe/payment_methods/card.ex
+++ b/lib/stripe/payment_methods/card.ex
@@ -98,7 +98,11 @@ defmodule Stripe.Card do
   If you want to create a card with your server without a token, you
   can use the low-level API.
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  @spec create(params, Keyword.t()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+              optional(:metadata) => Stripe.Types.metadata(),
+              optional(:source) => Stripe.id() | Stripe.Source.t(),
+            }
   def create(%{customer: _, source: _} = params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(params |> plural_endpoint())
@@ -110,7 +114,10 @@ defmodule Stripe.Card do
   @doc """
   Retrieve a card.
   """
-  @spec retrieve(Stripe.id() | t, map, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  @spec retrieve(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+              :id => String.t(),
+            }
   def retrieve(id, %{customer: _} = params, opts \\ []) do
     endpoint = params |> plural_endpoint()
 
@@ -125,7 +132,20 @@ defmodule Stripe.Card do
 
   Takes the `id` and a map of changes
   """
-  @spec update(Stripe.id() | t, map, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+              :id => String.t(),
+              optional(:address_city) => String.t(),
+              optional(:address_country) => String.t(),
+              optional(:address_line1) => String.t(),
+              optional(:address_line2) => String.t(),
+              optional(:address_state) => String.t(),
+              optional(:address_zip) => String.t(),
+              optional(:exp_month) => String.t(),
+              optional(:exp_year) => String.t(),
+              optional(:metadata) => Stripe.Types.metadata(),
+              optional(:name) => String.t(),
+            }
   def update(id, %{customer: _} = params, opts \\ []) do
     endpoint = params |> plural_endpoint()
 
@@ -139,7 +159,10 @@ defmodule Stripe.Card do
   @doc """
   Delete a card.
   """
-  @spec delete(Stripe.id() | t, map, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  @spec delete(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+               :id => String.t(),
+             }
   def delete(id, %{customer: _} = params, opts \\ []) do
     endpoint = params |> plural_endpoint()
 
@@ -152,7 +175,13 @@ defmodule Stripe.Card do
   @doc """
   List all cards.
   """
-  @spec list(map, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params: %{
+              :customer => Stripe.id() | Stripe.Customer.t(),
+              optional(:ending_before) => t | Stripe.id(),
+              optional(:limit) => 1..100,
+              optional(:starting_after) => t | Stripe.id(),
+            }
   def list(%{customer: _} = params, opts \\ []) do
     endpoint = params |> plural_endpoint()
     params = params |> Map.put(:object, "card")

--- a/lib/stripe/subscriptions/coupon.ex
+++ b/lib/stripe/subscriptions/coupon.ex
@@ -26,9 +26,7 @@ defmodule Stripe.Coupon do
           duration_in_months: pos_integer | nil,
           livemode: boolean,
           max_redemptions: pos_integer | nil,
-          metadata: %{
-            optional(String.t()) => String.t()
-          },
+          metadata: Stripe.Types.metadata(),
           percent_off: pos_integer | nil,
           redeem_by: Stripe.timestamp() | nil,
           times_redeemed: non_neg_integer,

--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -82,6 +82,7 @@ defmodule Stripe.Subscription do
                  }
                ],
                optional(:metadata) => Stripe.Types.metadata(),
+               optional(:prorate) => boolean,
                optional(:source) => Stripe.id() | Stripe.Source.t(),
                optional(:tax_percent) => float,
                optional(:trial_end) => Stripe.timestamp(),
@@ -156,6 +157,7 @@ defmodule Stripe.Subscription do
   """
   @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
         when params: %{
+               optional(:billing) => String.t(),
                optional(:created) => Stripe.date_query(),
                optional(:customer) => Stripe.Customer.t() | Stripe.id(),
                optional(:ending_before) => t | Stripe.id(),


### PR DESCRIPTION
@begedin 

- [x] cleanup params
- [x] cleaup types
- [x] ensure endpoints are implements + tested

https://stripe.com/docs/api#create_subscription

Just getting started and have a few questions:

1. Does the `Clean up the params.` mean the `@spec` params?  If so, what is the background on why and what is the scope of keys that should be included?
2. `Add from_json` macros - a bit confused.  Followed this back to `stripe/converter.ex`.  Is this already implemented for all modules given requests are all passed through `make_request` (which eventually calls `Converter.convert_result(result)`?


Progress on #266 