### PR TITLE
update stripe-mock to 0.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 sudo: false
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.3.0
+    - STRIPE_MOCK_VERSION=0.11.2
     - MIX_ENV=test STRIPE_SECRET_KEY=non_empty_secret_key_string
 cache:
   directories:

--- a/test/stripe/connect/account_test.exs
+++ b/test/stripe/connect/account_test.exs
@@ -24,8 +24,9 @@ defmodule Stripe.AccountTest do
   end
 
   test "is deletable" do
-    assert {:ok, %Stripe.Account{}} = Stripe.Account.delete("acct_123")
+    assert {:ok, %{deleted: deleted, id: _id}} = Stripe.Account.delete("acct_123")
     assert_stripe_requested(:delete, "/v1/accounts/acct_123")
+    assert deleted == true
   end
 
   test "is listable" do

--- a/test/stripe/core_resources/customer_test.exs
+++ b/test/stripe/core_resources/customer_test.exs
@@ -19,8 +19,9 @@ defmodule Stripe.CustomerTest do
 
   test "is deleteable" do
     {:ok, customer} = Stripe.Customer.retrieve("cus_123")
-    assert {:ok, %Stripe.Customer{}} = Stripe.Customer.delete(customer)
+    assert {:ok, %{deleted: deleted, id: _id}} = Stripe.Customer.delete(customer)
     assert_stripe_requested(:delete, "/v1/customers/#{customer.id}")
+    assert deleted === true
   end
 
   test "is listable" do

--- a/test/stripe/subscriptions/coupon_test.exs
+++ b/test/stripe/subscriptions/coupon_test.exs
@@ -25,7 +25,8 @@ defmodule Stripe.CouponTest do
   end
 
   test "is deleteable" do
-    assert {:ok, %Stripe.Coupon{}} = Stripe.Coupon.delete("25OFF")
+    assert {:ok, %{deleted: deleted, id: _id}} = Stripe.Coupon.delete("25OFF")
     assert_stripe_requested(:delete, "/v1/coupons/25OFF")
+    assert deleted == true
   end
 end

--- a/test/stripe/subscriptions/invoice_test.exs
+++ b/test/stripe/subscriptions/invoice_test.exs
@@ -66,18 +66,16 @@ defmodule Stripe.InvoiceTest do
   describe "pay/3" do
     test "pays an invoice" do
       {:ok, invoice} = Stripe.Invoice.retrieve("in_123")
-      assert {:ok, %Stripe.Invoice{} = paid_invoice} = Stripe.Invoice.pay(invoice, %{})
+      assert {:ok, %Stripe.Invoice{} = _paid_invoice} = Stripe.Invoice.pay(invoice, %{})
       assert_stripe_requested(:post, "/v1/invoices/#{invoice.id}/pay")
-      assert paid_invoice.paid
     end
 
     test "pays an invoice with a specific source" do
       {:ok, invoice} = Stripe.Invoice.retrieve("in_123")
       params = %{source: "src_123"}
-      assert {:ok, %Stripe.Invoice{} = paid_invoice} = Stripe.Invoice.pay(invoice, params)
+      assert {:ok, %Stripe.Invoice{} = _paid_invoice} = Stripe.Invoice.pay(invoice, params)
 
       assert_stripe_requested(:post, "/v1/invoices/#{invoice.id}/pay", body: %{source: "src_123"})
-      assert paid_invoice.paid
     end
   end
 

--- a/test/stripe/subscriptions/plan_test.exs
+++ b/test/stripe/subscriptions/plan_test.exs
@@ -34,8 +34,9 @@ defmodule Stripe.PlanTest do
   describe "delete/2" do
     test "deletes a Plan" do
       {:ok, plan} = Stripe.Plan.retrieve("sapphire-elite")
-      assert {:ok, %Stripe.Plan{}} = Stripe.Plan.delete(plan)
+      assert {:ok, %{deleted: deleted, id: _id}} = Stripe.Plan.delete(plan)
       assert_stripe_requested(:delete, "/v1/plans/#{plan.id}")
+      assert deleted === true
     end
   end
 


### PR DESCRIPTION
@begedin Updated stripe-mock to latest release.  Relatively minor changes in the response to a deleted resource.  `paid` was changed to false in the fixtures as well.

https://github.com/stripe/stripe-mock/releases

https://stripe.com/docs/api#delete_plan