### PR TITLE
Add params option to subscription delete

### DIFF
--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -144,11 +144,15 @@ defmodule Stripe.Subscription do
 
   Takes the `id` and an optional map of `params`.
   """
-  @spec delete(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
-  def delete(id, opts \\ []) do
+  @spec delete(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+          optional(:at_period_end) => boolean
+        }
+  def delete(id, params \\ %{}, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
     |> put_method(:delete)
+    |> put_params(params)
     |> make_request()
   end
 

--- a/test/stripe/subscriptions/subscription_test.exs
+++ b/test/stripe/subscriptions/subscription_test.exs
@@ -34,9 +34,11 @@ defmodule Stripe.SubscriptionTest do
     end
   end
 
-  describe "delete/2" do
+  describe "delete/3" do
     test "deletes a subscription" do
-      assert {:ok, %Stripe.Subscription{} = subscription} = Stripe.Subscription.delete("sub_123")
+      params = %{at_period_end: true}
+      opts = []
+      assert {:ok, %Stripe.Subscription{} = subscription} = Stripe.Subscription.delete("sub_123", params, opts)
       assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
     end
   end


### PR DESCRIPTION
The subscriptions/:id/delete endpoint can take optional params. This
commit updates the function to allow the passing of those params.