### PR TITLE
Add `account` field to Event

### DIFF
--- a/lib/stripe/core_resources/event.ex
+++ b/lib/stripe/core_resources/event.ex
@@ -67,7 +67,7 @@ defmodule Stripe.Event do
     :pending_webhooks,
     :request,
     :type,
-    :user_id
+    :account
   ]
 
   @plural_endpoint "events"

--- a/test/fixtures/event_with_customer.json
+++ b/test/fixtures/event_with_customer.json
@@ -1,6 +1,7 @@
 {
   "id": "evt_19YEx1BKl1F6IRFfb1cFLHzZ",
   "object": "event",
+  "account": "acct_0000000000000000",
   "api_version": "2016-07-06",
   "created": 1483537031,
   "data": {

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -5,6 +5,7 @@ defmodule Stripe.ConverterTest do
 
   test "converts a 'customer.updated' event response properly" do
     expected_result = %Stripe.Event{
+      account: "acct_0000000000000000",
       api_version: "2016-07-06",
       created: 1_483_537_031,
       data: %{
@@ -47,8 +48,7 @@ defmodule Stripe.ConverterTest do
       object: "event",
       pending_webhooks: 0,
       request: "req_9ryusbEBenV0BX",
-      type: "customer.updated",
-      user_id: nil
+      type: "customer.updated"
     }
 
     fixture = Helper.load_fixture("event_with_customer.json")


### PR DESCRIPTION
Events dispatched for Connect accounts contain the account id under the
field name `account`.

Resolves #392