### PR TITLE
Add support for object expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,43 @@ Create a connect standalone account. Grab your development `client_id`. Put it i
 </p>
 </details>
 
+# Object Expansion
+
+Some Stripe API endpoints support returning related objects via the object expansion query parameter. To take advantage of this feature, stripity_stripe accepts
+a list of strings to be passed into `opts` under the `:expand` key indicating which objects should be expanded.
+
+For example, calling `Charge.retrieve("ch_123")` would return a charge without expanding any objects.
+
+```elixir
+%Charge{
+  id: "ch_123",
+  balance_transaction: "txn_123",
+  ...
+}
+```
+
+However if we now include an expansion on the `balance_transaction` field using
+
+```elixir
+Charge.retrieve("ch_123", expand: ["balance_transaction"])
+```
+
+We will get the full object back as well.
+
+```elixir
+%Charge{
+  id: "ch_123",
+  balance_transaction: %BalanceTransaction{
+    id: "txn_123",
+    fee: 125,
+    ...
+  },
+  ...
+}
+```
+
+For details on which objects can be expanded check out the [stripe object expansion](https://stripe.com/docs/api#expanding_objects) docs.
+
 # Contributing
 
 Feedback, feature requests, and fixes are welcomed and encouraged.  Please make appropriate use of [Issues](https://github.com/code-corps/stripity-stripe/issues) and [Pull Requests](https://github.com/code-corps/stripity-stripe/pulls).  All code should have accompanying tests.

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -136,8 +136,10 @@ defmodule Stripe.API do
   @spec request(body, method, String.t(), headers, list) ::
           {:ok, map} | {:error, Stripe.Error.t()}
   def request(body, method, endpoint, headers, opts) do
+    {expansion, opts} = Keyword.pop(opts, :expand)
     base_url = get_base_url()
-    req_url = base_url <> endpoint
+
+    req_url = add_object_expansion("#{base_url}#{endpoint}", expansion)
 
     req_body =
       body
@@ -273,4 +275,15 @@ defmodule Stripe.API do
       _ -> body
     end
   end
+
+  defp add_object_expansion(url, expansion) when is_list(expansion) do
+    expand_str =
+      expansion
+      |> Enum.map(&"expand[]=#{&1}")
+      |> Enum.join("&")
+
+    "#{url}?#{expand_str}"
+  end
+
+  defp add_object_expansion(url, _), do: url
 end

--- a/lib/stripe/core_resources/balance.ex
+++ b/lib/stripe/core_resources/balance.ex
@@ -84,6 +84,7 @@ defmodule Stripe.Balance do
              }
   def list(params \\ %{}, opts \\ []) do
     new_request(opts)
+    |> prefix_expansions("data")
     |> put_endpoint(@endpoint <> "/history")
     |> put_method(:get)
     |> put_params(params)

--- a/lib/stripe/core_resources/charge.ex
+++ b/lib/stripe/core_resources/charge.ex
@@ -295,6 +295,7 @@ defmodule Stripe.Charge do
              }
   def list(params \\ %{}, opts \\ []) do
     new_request(opts)
+    |> prefix_expansions("data")
     |> put_endpoint(@plural_endpoint)
     |> put_method(:get)
     |> put_params(params)

--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -141,6 +141,7 @@ defmodule Stripe.Customer do
              } | %{}
   def list(params \\ %{}, opts \\ []) do
     new_request(opts)
+    |> prefix_expansions("data")
     |> put_endpoint(@plural_endpoint)
     |> put_method(:get)
     |> put_params(params)

--- a/lib/stripe/core_resources/dispute.ex
+++ b/lib/stripe/core_resources/dispute.ex
@@ -145,6 +145,7 @@ defmodule Stripe.Dispute do
              } | %{}
   def list(params \\ %{}, opts \\ []) do
     new_request(opts)
+    |> prefix_expansions("data")
     |> put_endpoint(@plural_endpoint)
     |> put_method(:get)
     |> put_params(params)

--- a/lib/stripe/core_resources/payout.ex
+++ b/lib/stripe/core_resources/payout.ex
@@ -141,6 +141,7 @@ defmodule Stripe.Payout do
              } | %{}
   def list(params \\ %{}, opts \\ []) do
     new_request(opts)
+    |> prefix_expansions("data")
     |> put_endpoint(@plural_endpoint)
     |> put_method(:get)
     |> put_params(params)

--- a/lib/stripe/core_resources/refund.ex
+++ b/lib/stripe/core_resources/refund.ex
@@ -140,6 +140,7 @@ defmodule Stripe.Refund do
              } | %{}
   def list(params \\ %{}, opts \\ []) do
     new_request(opts)
+    |> prefix_expansions("data")
     |> put_endpoint(@plural_endpoint)
     |> put_method(:get)
     |> put_params(params)

--- a/test/stripe/core_resources/charge_test.exs
+++ b/test/stripe/core_resources/charge_test.exs
@@ -29,4 +29,11 @@ defmodule Stripe.ChargeTest do
     assert {:ok, %Stripe.Charge{}} = Stripe.Charge.capture(charge, %{amount: 1000})
     assert_stripe_requested(:post, "/v1/charges/ch_123/capture")
   end
+
+  test "is retrievable with expansions opts" do
+    opts = [expand: ["balance_transaction"]]
+    assert {:ok, %Stripe.Charge{}} = Stripe.Charge.retrieve("ch_123", opts)
+
+    assert_stripe_requested(:get, "/v1/charges/ch_123")
+  end
 end

--- a/test/stripe/request_test.exs
+++ b/test/stripe/request_test.exs
@@ -1,0 +1,30 @@
+defmodule Stripe.RequestTest do
+  use ExUnit.Case
+
+  alias Stripe.Request
+
+  describe "object expansion" do
+    test "prefix_expansions/2 should apply the given prefix to the expansion values" do
+      opts = [expand: ["balance_transaction"]]
+      request = Request.prefix_expansions(%Request{opts: opts}, "data")
+      expansions = Keyword.get(request.opts, :expand)
+
+      assert expansions == ["data.balance_transaction"]
+    end
+
+    test "prefix_expansions/2 should apply the given prefix to multiple expansion values" do
+      opts = [expand: ["balance_transaction", "customer"]]
+      request = Request.prefix_expansions(%Request{opts: opts}, "data")
+      expansions = Keyword.get(request.opts, :expand)
+
+      assert expansions == ["data.balance_transaction", "data.customer"]
+    end
+
+    test "prefix_expansions/2 should return the original opts if no expansions specified" do
+      opts = []
+      request = Request.prefix_expansions(%Request{opts: opts}, "data")
+
+      assert request.opts == opts
+    end
+  end
+end


### PR DESCRIPTION
This PR adds basic support for object expansion as described [here](https://stripe.com/docs/api#expanding_objects) and aims to resolve #324.

I still need to add documentation/tests, however I wanted to check this is the desired way to do this before doing so.

These changes allow an `:expand` option with a list value to be passed via `opts` into any of the api functions on resources that support expansion. If an incorrect expansion is specified or one is specified on a resource that doesn't support it, the stripe api will return a 400 bad request.

Example usage

```elixir
Stripe.Charge.retrieve("ch_123", expand: [:balance_transaction, :customers])
```

or using a binary

```elixir
Stripe.Charge.retrieve("ch_123", expand: ["balance_transaction", "customers"])
```

I'm not entirely sure if having the `prefix_expansions` function in the request module is the correct place for this, any feedback on this would be great.