### PR TITLE
Add source_url to project definition

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Stripe.Mixfile do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls],
-      version: "2.1.0"
+      version: "2.1.0",
+      source_url: "https://github.com/code-corps/stripity_stripe/"
     ]
   end
 


### PR DESCRIPTION
Improves the ex_doc generated documentation by providing links to the github source.