### PR TITLE
 Add missing `unit_label` to Stripe.Product

### DIFF
--- a/lib/stripe/subscriptions/product.ex
+++ b/lib/stripe/subscriptions/product.ex
@@ -33,6 +33,7 @@ defmodule Stripe.Product do
     shippable: boolean | nil,
     statement_descriptor: String.t() | nil,
     type: String.t() | nil,
+    unit_label: String.t() | nil,
     updated: Stripe.timestamp(),
     url: String.t() | nil
   }
@@ -54,6 +55,7 @@ defmodule Stripe.Product do
     :shippable,
     :statement_descriptor,
     :type,
+    :unit_label,
     :updated,
     :url
   ]

--- a/test/stripe/subscriptions/product_test.exs
+++ b/test/stripe/subscriptions/product_test.exs
@@ -2,21 +2,21 @@ defmodule Stripe.ProductTest do
   use Stripe.StripeCase, async: true
 
   describe "create/2" do
-    test "creates an invoice" do
+    test "creates an product" do
       assert {:ok, %Stripe.Product{}} = Stripe.Product.create(%{name: "Plus", type: "service"})
       assert_stripe_requested(:post, "/v1/products")
     end
   end
 
   describe "retrieve/2" do
-    test "retrieves an invoice" do
+    test "retrieves an product" do
       assert {:ok, %Stripe.Product{}} = Stripe.Product.retrieve("Plus")
       assert_stripe_requested(:get, "/v1/products/Plus")
     end
   end
 
   describe "update/2" do
-    test "updates an invoice" do
+    test "updates an product" do
       params = %{metadata: %{key: "value"}}
       assert {:ok, %Stripe.Product{}} = Stripe.Product.update("Plus", params)
       assert_stripe_requested(:post, "/v1/products/Plus")


### PR DESCRIPTION
* Add  Stripe.Product params: :unit_label

* Fix Stripe.Product test descriptions