### PR TITLE
Convert discount response to struct

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -22,6 +22,7 @@ defmodule Stripe.Converter do
     country_spec
     coupon
     customer
+    discount
     dispute
     event
     external_account

--- a/test/fixtures/discount.json
+++ b/test/fixtures/discount.json
@@ -1,0 +1,24 @@
+{
+  "object": "discount",
+  "coupon": {
+      "id": "student-discount",
+      "object": "coupon",
+      "amount_off": null,
+      "created": 1532358691,
+      "currency": null,
+      "duration": "repeating",
+      "duration_in_months": 24,
+      "livemode": false,
+      "max_redemptions": null,
+      "metadata": {},
+      "name": "Student discount",
+      "percent_off": 50,
+      "redeem_by": null,
+      "times_redeemed": 3,
+      "valid": true
+  },
+  "customer": "cus_DCUJlLSyrGaqab",
+  "end": 1595517288,
+  "start": 1532358888,
+  "subscription": "sub_DG9Uq9WOevR9Uo"
+}

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -158,6 +158,37 @@ defmodule Stripe.ConverterTest do
     assert result == expected_result
   end
 
+  test "converts a discount response properly" do
+    expected_result = %Stripe.Discount{
+      coupon: %Stripe.Coupon{
+        amount_off: nil,
+        created: 1_532_358_691,
+        currency: nil,
+        duration: "repeating",
+        duration_in_months: 24,
+        id: "student-discount",
+        livemode: false,
+        max_redemptions: nil,
+        metadata: %{},
+        object: "coupon",
+        percent_off: 50,
+        redeem_by: nil,
+        times_redeemed: 3,
+        valid: true
+      },
+      customer: "cus_DCUJlLSyrGaqab",
+      end: 1_595_517_288,
+      object: "discount",
+      start: 1_532_358_888,
+      subscription: "sub_DG9Uq9WOevR9Uo"
+    }
+
+    fixture = Helper.load_fixture("discount.json")
+    result = Converter.convert_result(fixture)
+
+    assert result == expected_result
+  end
+
   test "converts a deleted response properly" do
     expected_result = %{
       deleted: true,


### PR DESCRIPTION
Previously, discounts were converted to bare maps. In this PR they are converted to the Stripe.Discount struct.

I've added a fixture and test case.