### PR TITLE
Ease up on the hackney dependency.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Stripe.Mixfile do
       {:earmark, "~> 1.2.5", only: :dev},
       {:ex_doc, "~> 0.18.3", only: :dev},
       {:excoveralls, "~> 0.8.1", only: :test},
-      {:hackney, "~> 1.12.1"},
+      {:hackney, "~> 1.13"},
       {:inch_ex, "~> 0.5", only: [:dev, :test]},
       {:mox, "~> 0.3", only: :test},
       {:poison, "~> 2.0 or ~> 3.0"},


### PR DESCRIPTION
Failed to use "hackney" (version 1.13.0) because
  ex_aws (version 2.1.0) requires 1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9
  httpoison (version 1.2.0) requires ~> 1.8
  stripity_stripe (versions 2.0.0 to 2.1.0) requires ~> 1.12.1
  swoosh (version 0.16.0) requires ~> 1.9
  mix.lock specifies 1.13.0