### PR TITLE
Add missing tax_info attributes to customer

### DIFF
--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -32,7 +32,9 @@ defmodule Stripe.Customer do
           metadata: Stripe.Types.metadata(),
           shipping: Stripe.Types.shipping() | nil,
           sources: Stripe.List.t(Stripe.Source.t()),
-          subscriptions: Stripe.List.t(Stripe.Subscription.t())
+          subscriptions: Stripe.List.t(Stripe.Subscription.t()),
+          tax_info: Stripe.Types.tax_info() | nil,
+          tax_info_verification: Stripe.Types.tax_info_verification() | nil
         }
 
   defstruct [
@@ -52,7 +54,9 @@ defmodule Stripe.Customer do
     :metadata,
     :shipping,
     :sources,
-    :subscriptions
+    :subscriptions,
+    :tax_info,
+    :tax_info_verification
   ]
 
   @plural_endpoint "customers"
@@ -71,7 +75,8 @@ defmodule Stripe.Customer do
                optional(:invoice_prefix) => String.t(),
                optional(:metadata) => Stripe.Types.metadata(),
                optional(:shipping) => Stripe.Types.shipping(),
-               optional(:source) => Stripe.Source.t()
+               optional(:source) => Stripe.Source.t(),
+               optional(:tax_info) => Stripe.Types.tax_info()
              } | %{}
   def create(params, opts \\ []) do
     new_request(opts)
@@ -107,7 +112,8 @@ defmodule Stripe.Customer do
                optional(:invoice_prefix) => String.t(),
                optional(:metadata) => Stripe.Types.metadata(),
                optional(:shipping) => Stripe.Types.shipping(),
-               optional(:source) => Stripe.Source.t()
+               optional(:source) => Stripe.Source.t(),
+               optional(:tax_info) => Stripe.Types.tax_info()
              } | %{}
   def update(id, params, opts \\ []) do
     new_request(opts)

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -32,6 +32,16 @@ defmodule Stripe.Types do
           tracking_number: String.t() | nil
         }
 
+  @type tax_info :: %{
+          type: String.t(),
+          tax_id: String.t() | nil,
+  }
+
+  @type tax_info_verification :: %{
+          status: String.t() | nil,
+          verified_name: String.t() | nil,
+  }
+
   @type transfer_schedule :: %{
           delay_days: non_neg_integer,
           interval: String.t(),


### PR DESCRIPTION
Adds missing tax_info and tax_info_verification properties to the api.

See: https://github.com/stripe/openapi/commit/ac55ea1efdabbfe85720948e07cd87a8f8177824#diff-4f009cc6cd6f5c91cfdc177413cfa2c7R2025
And https://stripe.com/docs/api#customer_object