### PR TITLE
Add customer field to Source entity

### DIFF
--- a/lib/stripe/payment_methods/source.ex
+++ b/lib/stripe/payment_methods/source.ex
@@ -10,6 +10,8 @@ defmodule Stripe.Source do
 
   @type source_type :: String.t()
 
+  @type customer :: String.t()
+
   @type ach_credit_transfer :: %{
           account_number: String.t() | nil,
           bank_name: String.t() | nil,
@@ -209,6 +211,7 @@ defmodule Stripe.Source do
     :code_verification,
     :created,
     :currency,
+    :customer,
     :eps,
     :flow,
     :giropay,

--- a/lib/stripe/payment_methods/source.ex
+++ b/lib/stripe/payment_methods/source.ex
@@ -10,7 +10,7 @@ defmodule Stripe.Source do
 
   @type source_type :: String.t()
 
-  @type customer :: String.t()
+  @type customer :: Stripe.id()
 
   @type ach_credit_transfer :: %{
           account_number: String.t() | nil,


### PR DESCRIPTION
Stripe added the customer field to the Source object. This PR adds that field to the Source struct.

https://stripe.com/docs/api/sources/object#source_object-customer