### PR TITLE
fix typespec for date query to make keys optional

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -49,10 +49,10 @@ defmodule Stripe do
 
   @type id :: String.t()
   @type date_query :: %{
-                   gt: timestamp,
-                   gte: timestamp,
-                   lt: timestamp,
-                   lte: timestamp
+                   optional(:gt) => timestamp,
+                   optional(:gte) => timestamp,
+                   optional(:lt) => timestamp,
+                   optional(:lte) => timestamp
                  }
   @type options :: Keyword.t()
   @type timestamp :: pos_integer


### PR DESCRIPTION
👋 Hi!
Many thanks for building and maintaining `stripity_stripe`. It makes integrating with Stripe really nice. I noticed that when I pulled it into my project I started to get a dialyzer error because I was doing a query like `Stripe.Event.list(%{created: %{gt: timestamp}, limit: 50, starting_after: cursor}, api: api_key)`

The call above works just fine, but dialyzer is throwing an error because the typespec for the datequery specifies all 4 keys of `gt`, `gte`, `lt`, `lte`. Putting all of them right into the typespec will [treat them as required keys](https://hexdocs.pm/elixir/typespecs.html#literals). So I just changed the typespec to make each of those keys optional the way they are documented [in the stripe api](https://stripe.com/docs/api/events/list#list_events-created).