### PR TITLE
add support for voiding invoices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ otp_release:
 sudo: false
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.38.0
+    - STRIPE_MOCK_VERSION=0.40.0
     - MIX_ENV=test STRIPE_SECRET_KEY=non_empty_secret_key_string
 cache:
   directories:

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -16,7 +16,7 @@ defmodule Stripe.API do
   @typep http_failure :: {:error, term}
 
   @pool_name __MODULE__
-  @api_version "2018-08-23"
+  @api_version "2018-11-08"
   @http_module Application.get_env(:stripity_stripe, :http_module) || :hackney
 
   def supervisor_children do

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -16,7 +16,7 @@ defmodule Stripe.API do
   @typep http_failure :: {:error, term}
 
   @pool_name __MODULE__
-  @api_version "2018-11-08"
+  @api_version "2018-08-23"
   @http_module Application.get_env(:stripity_stripe, :http_module) || :hackney
 
   def supervisor_children do

--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -7,6 +7,7 @@ defmodule Stripe.Invoice do
   - Create an invoice
   - Retrieve an invoice
   - Update an invoice
+  - Void an invoice
 
   Does not take options yet.
 
@@ -235,6 +236,17 @@ defmodule Stripe.Invoice do
     |> put_method(:post)
     |> put_params(params)
     |> cast_to_id([:source])
+    |> make_request()
+  end
+
+  @doc """
+  Void an invoice
+  """
+  @spec void(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def void(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}/void")
+    |> put_method(:post)
     |> make_request()
   end
 end

--- a/test/stripe/payment_methods/source_test.exs
+++ b/test/stripe/payment_methods/source_test.exs
@@ -33,8 +33,7 @@ defmodule Stripe.SourceTest do
 
   describe "detach/2" do
     test "detaches a source from a customer" do
-      assert {:ok, %{deleted: true, id: "src_123"}} =
-               Stripe.Source.detach("src_123", %{customer: "cus_123"})
+      assert {:ok, %{id: "src_123"}} = Stripe.Source.detach("src_123", %{customer: "cus_123"})
 
       assert_stripe_requested(:delete, "/v1/customers/cus_123/sources/src_123")
     end

--- a/test/stripe/subscriptions/invoice_test.exs
+++ b/test/stripe/subscriptions/invoice_test.exs
@@ -87,4 +87,12 @@ defmodule Stripe.InvoiceTest do
       assert %Stripe.Invoice{} = hd(invoices)
     end
   end
+
+  describe "void/2" do
+    test "voids an invoice" do
+      {:ok, invoice} = Stripe.Invoice.retrieve("in_123")
+      assert {:ok, %Stripe.Invoice{} = _voided_invoice} = Stripe.Invoice.void(invoice)
+      assert_stripe_requested(:post, "/v1/invoices/#{invoice.id}/void")
+    end
+  end
 end


### PR DESCRIPTION
closes #429

HOLD pending #439 

- update stripe-mock version to 0.40.0 ([latest](https://github.com/stripe/stripe-mock/releases))
- add `Stripe.Invoice#void/2` function