### PR TITLE
More configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ erl_crash.dump
 config/config.secret.exs
 /doc
 .DS_Store
+tags
 
 # elixir LS files
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ use Mix.Config
 config :stripity_stripe, api_key: "YOUR SECRET KEY"
 ```
 
-For security purposes it's possible to use a function or a tuple to resolve
-the secret:
+It's possible to use a function or a tuple to resolve the secret:
 
 ```ex
 config :stripity_stripe, api_key: {MyApp.Secrets, :stripe_secret, []}
@@ -142,7 +141,9 @@ config :stripity_stripe, platform_client_id: "YOUR CONNECT PLATFORM CLIENT ID"
 
 Moreover, if you are using Jason instead of Poison, you can configure the library to use Jason like so:
 
+```ex
 config :stripity_stripe, json_library: Jason
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ For security purposes it's possible to use a function or a tuple to resolve
 the secret:
 
 ```ex
-use Mix.Config
-
 config :stripity_stripe, api_key: {MyApp.Secrets, :stripe_secret, []}
 # OR
 config :stripity_stripe, api_key: fn -> System.get_env("STRIPE_SECRET") end

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ use Mix.Config
 config :stripity_stripe, api_key: "YOUR SECRET KEY"
 ```
 
+For security purposes it's possible to use a function or a tuple to resolve
+the secret:
+
+```ex
+use Mix.Config
+
+config :stripity_stripe, api_key: {MyApp.Secrets, :stripe_secret, []}
+# OR
+config :stripity_stripe, api_key: fn -> System.get_env("STRIPE_SECRET") end
+```
+
 ## Note: Object Expansion
 
 Some Stripe API endpoints support returning related objects via the object expansion query parameter. To take advantage of this feature, stripity_stripe accepts

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -17,13 +17,13 @@ defmodule Stripe.API do
 
   @pool_name __MODULE__
   @api_version "2018-08-23"
-  @http_module Application.get_env(:stripity_stripe, :http_module) || :hackney
 
   @doc """
   In config.exs your implicit or expicit configuration is:
     config :stripity_stripe,
       json_library: Jason # defaults to Poison but can be configured to Jason
   """
+  @spec json_library() :: module
   def json_library() do
     Config.resolve(:json_library, Poison)
   end
@@ -60,6 +60,11 @@ defmodule Stripe.API do
   @spec use_pool?() :: boolean
   defp use_pool?() do
     Config.resolve(:use_connection_pool)
+  end
+
+  @spec http_module() :: module
+  defp http_module() do
+    Config.resolve(:http_module, :hackney)
   end
 
   @spec add_common_headers(headers) :: headers
@@ -219,7 +224,7 @@ defmodule Stripe.API do
       |> add_default_options()
       |> add_pool_option()
 
-    @http_module.request(method, req_url, req_headers, req_body, req_opts)
+    http_module().request(method, req_url, req_headers, req_body, req_opts)
     |> handle_response()
   end
 
@@ -241,7 +246,7 @@ defmodule Stripe.API do
       |> add_default_options()
       |> add_pool_option()
 
-    @http_module.request(method, req_url, req_headers, body, req_opts)
+    http_module().request(method, req_url, req_headers, body, req_opts)
     |> handle_response()
   end
 

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -25,7 +25,7 @@ defmodule Stripe.API do
       json_library: Jason # defaults to Poison but can be configured to Jason
   """
   def json_library() do
-    Application.get_env(:stripity_stripe, :json_library, Poison)
+    Config.resolve(:json_library, Poison)
   end
 
   def supervisor_children do
@@ -54,7 +54,7 @@ defmodule Stripe.API do
   @spec get_default_api_key() :: String.t()
   defp get_default_api_key() do
     # if no API key is set default to `""` which will raise a Stripe API error
-    Config.resolve(:api_key) || ""
+    Config.resolve(:api_key, "")
   end
 
   @spec use_pool?() :: boolean

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -5,7 +5,7 @@ defmodule Stripe.API do
   Usually the utilities in `Stripe.Request` are a better way to write custom interactions with
   the API.
   """
-  alias Stripe.Error
+  alias Stripe.{Config, Error}
 
   @callback oauth_request(method, String.t(), map) :: {:ok, map}
 
@@ -38,34 +38,28 @@ defmodule Stripe.API do
 
   @spec get_pool_options() :: Keyword.t()
   defp get_pool_options() do
-    Application.get_env(:stripity_stripe, :pool_options)
+    Config.resolve(:pool_options)
   end
 
   @spec get_base_url() :: String.t()
   defp get_base_url() do
-    Application.get_env(:stripity_stripe, :api_base_url)
+    Config.resolve(:api_base_url)
   end
 
   @spec get_upload_url() :: String.t()
   defp get_upload_url() do
-    Application.get_env(:stripity_stripe, :api_upload_url)
+    Config.resolve(:api_upload_url)
   end
 
   @spec get_default_api_key() :: String.t()
   defp get_default_api_key() do
-    case Application.get_env(:stripity_stripe, :api_key) do
-      nil ->
-        # use an empty string and let Stripe produce an error
-        ""
-
-      key ->
-        key
-    end
+    # if no API key is set default to `""` which will raise a Stripe API error
+    Config.resolve(:api_key) || ""
   end
 
   @spec use_pool?() :: boolean
   defp use_pool?() do
-    Application.get_env(:stripity_stripe, :use_connection_pool)
+    Config.resolve(:use_connection_pool)
   end
 
   @spec add_common_headers(headers) :: headers

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -10,9 +10,9 @@ defmodule Stripe.Config do
   wrapped expanded value. If the value was a function it get's evaluated, if
   the value is a touple of three elements it gets applied.
   """
-  @spec resolve(atom) :: any
-  def resolve(key) do
-    Application.get_env(@base_key, key)
+  @spec resolve(atom, any) :: any
+  def resolve(key, default // nil) do
+    Application.get_env(@base_key, key, default)
     |> expand_value()
   end
 

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -11,9 +11,12 @@ defmodule Stripe.Config do
   the value is a touple of three elements it gets applied.
   """
   @spec resolve(atom, any) :: any
-  def resolve(key, default // nil) do
+  def resolve(key, default // nil) when is_atom(key) do
     Application.get_env(@base_key, key, default)
     |> expand_value()
+  end
+  def resolve(key, _) do
+    raise("#{__MODULE__} expected key '#{key}' to be an atom")
   end
 
   defp expand_value({module, function, args})

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -11,7 +11,7 @@ defmodule Stripe.Config do
   the value is a touple of three elements it gets applied.
   """
   @spec resolve(atom, any) :: any
-  def resolve(key, default // nil) when is_atom(key) do
+  def resolve(key, default \\ nil) when is_atom(key) do
     Application.get_env(@base_key, key, default)
     |> expand_value()
   end

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -3,8 +3,6 @@ defmodule Stripe.Config do
   Utility that handles interaction with the application's configuration
   """
 
-  @base_key :stripity_stripe
-
   @doc """
   Resolves the given key from the application's configuration returning the
   wrapped expanded value. If the value was a function it get's evaluated, if
@@ -13,7 +11,7 @@ defmodule Stripe.Config do
   @spec resolve(atom, any) :: any
   def resolve(key, default \\ nil)
   def resolve(key, default) when is_atom(key) do
-    Application.get_env(@base_key, key, default)
+    Application.get_env(:stripity_stripe, key, default)
     |> expand_value()
   end
   def resolve(key, _) do

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -11,12 +11,16 @@ defmodule Stripe.Config do
   the value is a touple of three elements it gets applied.
   """
   @spec resolve(atom, any) :: any
-  def resolve(key, default \\ nil) when is_atom(key) do
+  def resolve(key, default \\ nil)
+  def resolve(key, default) when is_atom(key) do
     Application.get_env(@base_key, key, default)
     |> expand_value()
   end
   def resolve(key, _) do
-    raise("#{__MODULE__} expected key '#{key}' to be an atom")
+    raise(
+      ArgumentError,
+      message: "#{__MODULE__} expected key '#{key}' to be an atom"
+    )
   end
 
   defp expand_value({module, function, args})

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -8,9 +8,9 @@ defmodule Stripe.Config do
   @doc """
   Resolves the given key from the application's configuration returning the
   wrapped expanded value. If the value was a function it get's evaluated, if
-  the value vas a touple of three elements it gets applied.
+  the value is a touple of three elements it gets applied.
   """
-  @spec resolve(any) :: any
+  @spec resolve(atom) :: any
   def resolve(key) do
     Application.get_env(@base_key, key)
     |> expand_value()

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -1,0 +1,28 @@
+defmodule Stripe.Config do
+  @moduledoc """
+  Utility that handles interaction with the application's configuration
+  """
+
+  @base_key :stripity_stripe
+
+  @doc """
+  Resolves the given key from the application's configuration returning the
+  wrapped expanded value. If the value was a function it get's evaluated, if
+  the value vas a touple of three elements it gets applied.
+  """
+  @spec resolve(any) :: any
+  def resolve(key) do
+    Application.get_env(@base_key, key)
+    |> expand_value()
+  end
+
+  defp expand_value({module, function, args})
+  when is_atom(function) and is_list(args)
+  do
+    apply(module, function, args)
+  end
+  defp expand_value(value) when is_function(value) do
+    value.()
+  end
+  defp expand_value(value), do: value
+end

--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -11,7 +11,7 @@ defmodule Stripe.Connect.OAuth do
   Stripe API reference: https://stripe.com/docs/connect/reference
   """
 
-  alias Stripe.Converter
+  alias Stripe.{Config, Converter}
 
   @callback token(code :: String.t()) :: {:ok, map}
   @callback authorize_url(map) :: String.t()
@@ -188,12 +188,12 @@ defmodule Stripe.Connect.OAuth do
 
   @spec get_client_id() :: String.t()
   defp get_client_id() do
-    Application.get_env(:stripity_stripe, :connect_client_id)
+    Config.resolve(:connect_client_id)
   end
 
   @spec get_client_secret() :: String.t()
   defp get_client_secret() do
-    Application.get_env(:stripity_stripe, :api_key)
+    Config.resolve(:api_key)
   end
 
   @spec get_default_authorize_map() :: map

--- a/test/stripe/config_test.exs
+++ b/test/stripe/config_test.exs
@@ -1,0 +1,28 @@
+defmodule Stripe.ConfigTest do
+  use ExUnit.Case
+
+  defmodule ValueExpansionTestModule do
+    def value do
+      "test-test"
+    end
+  end
+
+  test "returns the requested configuration value" do
+    Application.put_env(:stripity_stripe, :__test, "test-test")
+    assert(Stripe.Config.resolve(:__test) == "test-test")
+  end
+
+  test "evaluates functions" do
+    Application.put_env(:stripity_stripe, :__test, fn -> "test-test" end)
+    assert(Stripe.Config.resolve(:__test) == "test-test")
+  end
+
+  test "applies tuples" do
+    Application.put_env(
+      :stripity_stripe,
+      :__test,
+      {ValueExpansionTestModule, :value, []}
+    )
+    assert(Stripe.Config.resolve(:__test) == "test-test")
+  end
+end

--- a/test/stripe/config_test.exs
+++ b/test/stripe/config_test.exs
@@ -25,4 +25,25 @@ defmodule Stripe.ConfigTest do
     )
     assert(Stripe.Config.resolve(:__test) == "test-test")
   end
+
+  test "if no value exists for the given key it uses the default value" do
+    Application.put_env(
+      :stripity_stripe,
+      :__test,
+      {ValueExpansionTestModule, :value, []}
+    )
+    assert(Stripe.Config.resolve(:__fake_test, "test-test") == "test-test")
+  end
+
+  test "raises if the key isn't an atom" do
+    Application.put_env(
+      :stripity_stripe,
+      :__test,
+      {ValueExpansionTestModule, :value, []}
+    )
+
+    assert_raise ArgumentError, ~r/to be an atom/, fn ->
+      Stripe.Config.resolve("__test", "test-test")
+    end
+  end
 end


### PR DESCRIPTION
This patch enables configuration variables to be dynamically configured through functions or tuples.

The motivation behind this patch is to give users the ability to load configuration variables from the environment or to compute them - thus removing them from the configuration file.

Instead of passing the secret key as a string directly, which might be hard to avoid in some cases, this patch enables the user to pass a function

```elixir
config :stripity_stripe, api_key: fn -> System.get_env("STRIPE_SECRET") end
```

Or to pass a tuple which contains three elements, of which the second is an atom, and the third is a list

```ex
config :stripity_stripe, api_key: {MyApp.Secrets, :stripe_secret, []}
```