### PR TITLE
Add elixir 1.8 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ elixir:
   - 1.5
   - 1.6
   - 1.7
+  - 1.8
 otp_release:
   - 19.3
   - 20.1
+matrix:
+  exclude:
+    - otp_release: 19.3
+      elixir: 1.8
 sudo: false
 env:
   global:


### PR DESCRIPTION
Exclude elixir 1.8 from testing under otp 19.3 as it is not supported
(https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-non-major-elixir-versions)