### PR TITLE
Use singular time units in System.system_time/1

### DIFF
--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -94,7 +94,7 @@ defmodule Stripe.Webhook do
   end
 
   defp check_timestamp(timestamp, tolerance) do
-    now = System.system_time(:seconds)
+    now = System.system_time(:second)
     tolerance_zone = now - tolerance
 
     if timestamp < tolerance_zone do

--- a/test/stripe/webhook_test.exs
+++ b/test/stripe/webhook_test.exs
@@ -20,7 +20,7 @@ defmodule Stripe.WebhookTest do
   end
 
   test "payload with a valid signature should return event" do
-    timestamp = System.system_time(:seconds)
+    timestamp = System.system_time(:second)
     payload = @valid_payload
     signature = generate_signature(timestamp, payload)
     signature_header = create_signature_header(timestamp, @valid_scheme, signature)
@@ -29,7 +29,7 @@ defmodule Stripe.WebhookTest do
   end
 
   test "payload with an invalid signature should fail" do
-    timestamp = System.system_time(:seconds)
+    timestamp = System.system_time(:second)
     payload = @valid_payload
     signature = generate_signature(timestamp, "random")
     signature_header = create_signature_header(timestamp, @valid_scheme, signature)
@@ -38,7 +38,7 @@ defmodule Stripe.WebhookTest do
   end
 
   test "payload with wrong secret should fail" do
-    timestamp = System.system_time(:seconds)
+    timestamp = System.system_time(:second)
     payload = @valid_payload
     signature = generate_signature(timestamp, payload, "wrong")
     signature_header = create_signature_header(timestamp, @valid_scheme, signature)
@@ -47,7 +47,7 @@ defmodule Stripe.WebhookTest do
   end
 
   test "payload with missing signature scheme should fail" do
-    timestamp = System.system_time(:seconds)
+    timestamp = System.system_time(:second)
     payload = @valid_payload
     signature = generate_signature(timestamp, payload)
     signature_header = create_signature_header(timestamp, @invalid_scheme, signature)


### PR DESCRIPTION
Plural is deprecated and gives an error:
warning: deprecated time unit: :seconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer