### PR TITLE
add shared options to documentation

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -23,9 +23,9 @@ defmodule Stripe do
 
     * `:api_key` - The Stripe API key to use for the request. See
       [https://stripe.com/docs/api/authentication](https://stripe.com/docs/api/authentication)
-    * `:connect_account` - A Stripe Connect account ID which should originate
-      the specified action using the "Stripe-Account" header. The preferred
-      authentication method for Stripe Connect. See
+    * `:connect_account` - The ID of a Stripe Connect account for which the
+      request should be made, passed through as the "Stripe-Account" header. The
+      preferred authentication method for Stripe Connect. See
       [https://stripe.com/docs/connect/authentication#stripe-account-header](https://stripe.com/docs/connect/authentication#stripe-account-header)
     * `:expand` - Takes a list of fields that should be expanded in the response
       from Stripe. See [https://stripe.com/docs/api/expanding_objects](https://stripe.com/docs/api/expanding_objects)

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -17,6 +17,19 @@ defmodule Stripe do
 
       config :stripity_stripe, api_key: System.get_env("STRIPE_API_KEY")
 
+  ### Shared Options
+
+  Almost all of the requests that can be sent accept the following options:
+
+    * `:api_key` - The Stripe API key to use for the request. See
+      [https://stripe.com/docs/api/authentication](https://stripe.com/docs/api/authentication)
+    * `:connect_account` - A Stripe Connect account ID which should originate
+      the specified action using the "Stripe-Account" header. The preferred
+      authentication method for Stripe Connect. See
+      [https://stripe.com/docs/connect/authentication#stripe-account-header](https://stripe.com/docs/connect/authentication#stripe-account-header)
+    * `:expand` - Takes a list of fields that should be expanded in the response
+      from Stripe. See [https://stripe.com/docs/api/expanding_objects](https://stripe.com/docs/api/expanding_objects)
+
   ### HTTP Connection Pool
 
   Stripity Stripe is set up to use an HTTP connection pool by default. This


### PR DESCRIPTION
Similar to #441 I had a hard time figuring out how to create a charge on a connected account using the `Stripe-Account` header. Because of that, I submit that documentation around available options should be added. I'd love feedback on exactly where to put that documentation, but I think since it's available in almost every function it should be at a high level.

This PR will add a section to the `Stripe` docs that looks like this:
![new documentation section](https://user-images.githubusercontent.com/3421625/51340360-f6620880-1a4b-11e9-88a2-edb007392aca.png)
