### PR TITLE
Add support for idempotent post requests

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -29,6 +29,8 @@ defmodule Stripe do
       [https://stripe.com/docs/connect/authentication#stripe-account-header](https://stripe.com/docs/connect/authentication#stripe-account-header)
     * `:expand` - Takes a list of fields that should be expanded in the response
       from Stripe. See [https://stripe.com/docs/api/expanding_objects](https://stripe.com/docs/api/expanding_objects)
+    * `:idempotency_key` - A string that is passed through as the "Idempotency-Key" header on all POST requests. This is used by Stripe's idempotency layer to manage
+      duplicate requests to the stripe API. See [https://stripe.com/docs/api/idempotent_requests](https://stripe.com/docs/api/idempotent_requests)
 
   ### HTTP Connection Pool
 

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -159,9 +159,11 @@ defmodule Stripe.API do
 
   def request(body, method, endpoint, headers, opts) do
     {expansion, opts} = Keyword.pop(opts, :expand)
-    base_url = get_base_url()
+    {idempotency_key, opts} = Keyword.pop(opts, :idempotency_key)
 
+    base_url = get_base_url()
     req_url = add_object_expansion("#{base_url}#{endpoint}", expansion)
+    headers = add_idempotency_header(idempotency_key, headers, method)
 
     req_body =
       body
@@ -309,4 +311,12 @@ defmodule Stripe.API do
   end
 
   defp add_object_expansion(url, _), do: url
+
+  defp add_idempotency_header(nil, headers, _), do: headers
+
+  defp add_idempotency_header(idempotency_key, headers, :post) do
+    Map.put(headers, "Idempotency-Key", idempotency_key)
+  end
+
+  defp add_idempotency_header(_, headers, _), do: headers
 end

--- a/test/stripe/core_resources/charge_test.exs
+++ b/test/stripe/core_resources/charge_test.exs
@@ -30,6 +30,13 @@ defmodule Stripe.ChargeTest do
     assert_stripe_requested(:post, "/v1/charges/ch_123/capture")
   end
 
+  test "is captureable with idempotency opts" do
+    opts = [idempotency_key: "test"]
+    {:ok, %Stripe.Charge{} = charge} = Stripe.Charge.retrieve("ch_123")
+    assert {:ok, %Stripe.Charge{}} = Stripe.Charge.capture(charge, %{amount: 1000}, opts)
+    assert_stripe_requested(:post, "/v1/charges/ch_123/capture")
+  end
+
   test "is retrievable with expansions opts" do
     opts = [expand: ["balance_transaction"]]
     assert {:ok, %Stripe.Charge{}} = Stripe.Charge.retrieve("ch_123", opts)


### PR DESCRIPTION
Adds support for allowing the client to make idempotent requests to the Stripe API as described [here](https://stripe.com/docs/api/idempotent_requests).

These changes add a new `:idempotency_key` option that can be specified when taking an action that will cause a POST request (such as creating a charge).

Example usage

```elixir
Stripe.Charge.create(charge, %{amount: 1000}, idempotency_key: "some-unique-value")
```

Using the idempotency key allows the client to make the same charge request multiple times without the risk of creating duplicate charges on Stripe. This is useful where the outcome of the initial charge request is unknown, maybe due to some form of networking issues or request timeout.