### PR TITLE
Implement `assert_stripe_requested/3`

### DIFF
--- a/lib/stripe/payment_methods/bank_account.ex
+++ b/lib/stripe/payment_methods/bank_account.ex
@@ -144,7 +144,7 @@ defmodule Stripe.BankAccount do
              }
   def list(%{customer: _} = params, opts \\ []) do
     endpoint = params |> plural_endpoint()
-    params = params |> Map.put(:object, "card")
+    params = params |> Map.put(:object, "bank_account")
 
     new_request(opts)
     |> put_endpoint(endpoint)

--- a/test/stripe/connect/account_test.exs
+++ b/test/stripe/connect/account_test.exs
@@ -38,6 +38,8 @@ defmodule Stripe.AccountTest do
   test "is rejectable" do
     {:ok, account} = Stripe.Account.create(%{metadata: %{}, type: "standard"})
 
+    assert_stripe_requested(:post, "/v1/accounts")
+
     assert {:ok, %Stripe.Account{} = rejected_account} =
              Stripe.Account.reject(account, "terms_of_service")
 

--- a/test/stripe/connect/fee_refund_test.exs
+++ b/test/stripe/connect/fee_refund_test.exs
@@ -3,8 +3,9 @@ defmodule Stripe.FeeRefundTest do
 
   describe "retrieve/2" do
     test "retrieves a transfer" do
-      assert {:ok, %Stripe.FeeRefund{}} = Stripe.FeeRefund.retrieve("transf_123", "rev_123")
-      assert_stripe_requested(:get, "/v1/appliction_fees/trasnf_123/reversals/rev_123")
+      assert {:ok, %Stripe.FeeRefund{}} = Stripe.FeeRefund.retrieve("fee_123", "fr_123")
+
+      assert_stripe_requested(:get, "/v1/application_fees/fee_123/refunds/fr_123")
     end
   end
 
@@ -14,25 +15,25 @@ defmodule Stripe.FeeRefundTest do
         amount: 123
       }
 
-      assert {:ok, %Stripe.FeeRefund{}} = Stripe.FeeRefund.create("transf_123", params)
-      assert_stripe_requested(:post, "/v1/appliction_fees/transf_123/reversals")
+      assert {:ok, %Stripe.FeeRefund{}} = Stripe.FeeRefund.create("fee_123", params)
+      assert_stripe_requested(:post, "/v1/application_fees/fee_123/refunds")
     end
   end
 
   describe "update/2" do
     test "updates a transfer" do
       params = %{metadata: %{foo: "bar"}}
-      assert {:ok, transfer} = Stripe.FeeRefund.update("trasnf_123", "rev_123", params)
-      assert_stripe_requested(:post, "/v1/appliction_fees/#{transfer.id}/reversals/rev_123")
+      assert {:ok, _transfer} = Stripe.FeeRefund.update("fee_123", "fr_123", params)
+      assert_stripe_requested(:post, "/v1/application_fees/fee_123/refunds/fr_123")
     end
   end
 
   describe "list/2" do
-    test "lists all appliction_fees refunds" do
-      assert {:ok, %Stripe.List{data: appliction_fees}} = Stripe.FeeRefund.list("transf_123")
-      assert_stripe_requested(:get, "/v1/appliction_fees/transf_123/reversals")
-      assert is_list(appliction_fees)
-      assert %Stripe.FeeRefund{} = hd(appliction_fees)
+    test "lists all application_fees refunds" do
+      assert {:ok, %Stripe.List{data: application_fees}} = Stripe.FeeRefund.list("fee_123")
+      assert_stripe_requested(:get, "/v1/application_fees/fee_123/refunds")
+      assert is_list(application_fees)
+      assert %Stripe.FeeRefund{} = hd(application_fees)
     end
   end
 end

--- a/test/stripe/connect/transfer_reversal_test.exs
+++ b/test/stripe/connect/transfer_reversal_test.exs
@@ -4,9 +4,9 @@ defmodule Stripe.TransferReversalTest do
   describe "retrieve/2" do
     test "retrieves a transfer" do
       assert {:ok, %Stripe.TransferReversal{}} =
-               Stripe.TransferReversal.retrieve("transf_123", "rev_123")
+               Stripe.TransferReversal.retrieve("tr_123", "trr_456")
 
-      assert_stripe_requested(:get, "/v1/transfers/trasnf_123/reversals/rev_123")
+      assert_stripe_requested(:get, "/v1/transfers/tr_123/reversals/trr_456")
     end
   end
 
@@ -17,24 +17,25 @@ defmodule Stripe.TransferReversalTest do
       }
 
       assert {:ok, %Stripe.TransferReversal{}} =
-               Stripe.TransferReversal.create("transf_123", params)
+               Stripe.TransferReversal.create("tr_123", params)
 
-      assert_stripe_requested(:post, "/v1/transfers/transf_123/reversals")
+      assert_stripe_requested(:post, "/v1/transfers/tr_123/reversals")
     end
   end
 
   describe "update/2" do
     test "updates a transfer" do
       params = %{metadata: %{foo: "bar"}}
-      assert {:ok, transfer} = Stripe.TransferReversal.update("trasnf_123", "rev_123", params)
-      assert_stripe_requested(:post, "/v1/transfers/#{transfer.id}/reversals/rev_123")
+      assert {:ok, _transfer_reversal} = Stripe.TransferReversal.update("tr_123", "trr_456", params)
+
+      assert_stripe_requested(:post, "/v1/transfers/tr_123/reversals/trr_456")
     end
   end
 
   describe "list/2" do
     test "lists all transfers" do
-      assert {:ok, %Stripe.List{data: transfers}} = Stripe.TransferReversal.list("transf_123")
-      assert_stripe_requested(:get, "/v1/transfers/transf_123/reversals")
+      assert {:ok, %Stripe.List{data: transfers}} = Stripe.TransferReversal.list("tr_123")
+      assert_stripe_requested(:get, "/v1/transfers/tr_123/reversals")
       assert is_list(transfers)
       assert %Stripe.TransferReversal{} = hd(transfers)
     end

--- a/test/stripe/core_resources/charge_test.exs
+++ b/test/stripe/core_resources/charge_test.exs
@@ -26,6 +26,8 @@ defmodule Stripe.ChargeTest do
 
   test "is captureable" do
     {:ok, %Stripe.Charge{} = charge} = Stripe.Charge.retrieve("ch_123")
+    assert_stripe_requested(:get, "/v1/charges/ch_123")
+
     assert {:ok, %Stripe.Charge{}} = Stripe.Charge.capture(charge, %{amount: 1000})
     assert_stripe_requested(:post, "/v1/charges/ch_123/capture")
   end
@@ -33,14 +35,21 @@ defmodule Stripe.ChargeTest do
   test "is captureable with idempotency opts" do
     opts = [idempotency_key: "test"]
     {:ok, %Stripe.Charge{} = charge} = Stripe.Charge.retrieve("ch_123")
+    assert_stripe_requested(:get, "/v1/charges/ch_123")
+
     assert {:ok, %Stripe.Charge{}} = Stripe.Charge.capture(charge, %{amount: 1000}, opts)
-    assert_stripe_requested(:post, "/v1/charges/ch_123/capture")
+
+    assert_stripe_requested(:post, "/v1/charges/ch_123/capture",
+      headers: {"Idempotency-Key", "test"}
+    )
   end
 
   test "is retrievable with expansions opts" do
     opts = [expand: ["balance_transaction"]]
     assert {:ok, %Stripe.Charge{}} = Stripe.Charge.retrieve("ch_123", opts)
 
-    assert_stripe_requested(:get, "/v1/charges/ch_123")
+    assert_stripe_requested(:get, "/v1/charges/ch_123",
+      query: %{"expand[0]": "balance_transaction"}
+    )
   end
 end

--- a/test/stripe/core_resources/customer_test.exs
+++ b/test/stripe/core_resources/customer_test.exs
@@ -19,6 +19,8 @@ defmodule Stripe.CustomerTest do
 
   test "is deletable" do
     {:ok, customer} = Stripe.Customer.retrieve("cus_123")
+    assert_stripe_requested(:get, "/v1/customers/#{customer.id}")
+
     assert {:ok, %Stripe.Customer{}} = Stripe.Customer.delete(customer)
     assert_stripe_requested(:delete, "/v1/customers/#{customer.id}")
   end
@@ -33,6 +35,8 @@ defmodule Stripe.CustomerTest do
   describe "delete_discount/2" do
     test "deletes a customer's discount" do
       {:ok, customer} = Stripe.Customer.retrieve("sub_123")
+      assert_stripe_requested(:get, "/v1/customers/#{customer.id}")
+
       assert {:ok, _} = Stripe.Customer.delete_discount("sub_123")
       assert_stripe_requested(:delete, "/v1/customers/#{customer.id}/discount")
     end

--- a/test/stripe/core_resources/dispute_test.exs
+++ b/test/stripe/core_resources/dispute_test.exs
@@ -14,6 +14,8 @@ defmodule Stripe.DisputeTest do
 
   test "is closeable" do
     {:ok, dispute} = Stripe.Dispute.retrieve("cus_123")
+    assert_stripe_requested(:get, "/v1/disputes/#{dispute.id}")
+
     assert {:ok, %Stripe.Dispute{}} = Stripe.Dispute.close(dispute)
     assert_stripe_requested(:post, "/v1/disputes/#{dispute.id}/close")
   end

--- a/test/stripe/core_resources/payment_intent_test.exs
+++ b/test/stripe/core_resources/payment_intent_test.exs
@@ -42,6 +42,8 @@ defmodule Stripe.PaymentIntentTest do
   test "is captureable" do
     {:ok, %Stripe.PaymentIntent{} = payment_intent} = Stripe.PaymentIntent.retrieve("pi_123", %{})
 
+    assert_stripe_requested(:get, "/v1/payment_intents/pi_123")
+
     assert {:ok, %Stripe.PaymentIntent{}} =
              Stripe.PaymentIntent.capture(payment_intent, %{amount_to_capture: 1000})
 

--- a/test/stripe/core_resources/payout_test.exs
+++ b/test/stripe/core_resources/payout_test.exs
@@ -35,7 +35,7 @@ defmodule Stripe.PayoutTest do
   describe "cancel/1" do
     test "cancels a payout" do
       assert {:ok, %Stripe.Payout{}} = Stripe.Payout.cancel("py_123")
-      assert_stripe_requested(:get, "/v1/payouts/cancel")
+      assert_stripe_requested(:post, "/v1/payouts/py_123/cancel")
     end
   end
 end

--- a/test/stripe/relay/order_test.exs
+++ b/test/stripe/relay/order_test.exs
@@ -26,7 +26,7 @@ defmodule Stripe.OrderTest do
   describe "pay/3" do
     test "is payable" do
       assert {:ok, %Stripe.Order{}} = Stripe.Order.pay("order_123")
-      assert_stripe_requested(:pay, "/v1/orders/order_123/pay")
+      assert_stripe_requested(:post, "/v1/orders/order_123/pay")
     end
 
     @tag :skip
@@ -36,14 +36,14 @@ defmodule Stripe.OrderTest do
       }
 
       assert {:ok, %Stripe.Order{}} = Stripe.Order.pay("order_123", params)
-      assert_stripe_requested(:pay, "/v1/orders/order_123/pay")
+      assert_stripe_requested(:post, "/v1/orders/order_123/pay")
     end
   end
 
   describe "return/3" do
     test "is returnable" do
       assert {:ok, %Stripe.OrderReturn{}} = Stripe.Order.return("order_123")
-      assert_stripe_requested(:pay, "/v1/orders/order_123/returns")
+      assert_stripe_requested(:post, "/v1/orders/order_123/returns")
     end
   end
 
@@ -58,7 +58,7 @@ defmodule Stripe.OrderTest do
     test "is listable with params" do
       params = %{status: "paid"}
       assert {:ok, %Stripe.List{data: orders}} = Stripe.Order.list(params)
-      assert_stripe_requested(:get, "/v1/orders")
+      assert_stripe_requested(:get, "/v1/orders", query: params)
       assert is_list(orders)
       assert %Stripe.Order{} = hd(orders)
     end

--- a/test/stripe/relay/product_test.exs
+++ b/test/stripe/relay/product_test.exs
@@ -40,7 +40,7 @@ defmodule Stripe.Relay.ProductTest do
     test "lists all products with params" do
       params = %{active: false}
       assert {:ok, %Stripe.List{data: products}} = Stripe.Product.list(params)
-      assert_stripe_requested(:get, "/v1/products")
+      assert_stripe_requested(:get, "/v1/products", query: %{active: false})
       assert is_list(products)
       assert %Stripe.Product{} = hd(products)
     end
@@ -49,6 +49,8 @@ defmodule Stripe.Relay.ProductTest do
   describe "delete/1" do
     test "deletes a product" do
       {:ok, product} = Stripe.Product.retrieve("Plus")
+      assert_stripe_requested(:get, "/v1/products/#{product.id}")
+
       assert {:ok, _} = Stripe.Product.delete("Plus")
       assert_stripe_requested(:delete, "/v1/products/#{product.id}")
     end

--- a/test/stripe/relay/sku_test.exs
+++ b/test/stripe/relay/sku_test.exs
@@ -34,7 +34,7 @@ defmodule Stripe.SkuTest do
 
   test "is deletable" do
     assert {:ok, %Stripe.Sku{}} = Stripe.Sku.delete("sku_123")
-    assert_stripe_requested(:delete, "/v1/skus/sku_123/delete")
+    assert_stripe_requested(:delete, "/v1/skus/sku_123")
   end
 
   test "is listable" do
@@ -47,6 +47,6 @@ defmodule Stripe.SkuTest do
   test "is listable with params" do
     params = %{active: false, in_stock: false}
     assert {:ok, %Stripe.List{data: _skus}} = Stripe.Sku.list(params)
-    assert_stripe_requested(:get, "/v1/skus")
+    assert_stripe_requested(:get, "/v1/skus", query: params)
   end
 end

--- a/test/stripe/subscriptions/invoice_test.exs
+++ b/test/stripe/subscriptions/invoice_test.exs
@@ -23,7 +23,7 @@ defmodule Stripe.InvoiceTest do
       assert_stripe_requested(
         :get,
         "/v1/invoices/upcoming",
-        query: %{customer: "cust_123", subscription: "sub_123"}
+        query: %{customer: "cus_123", subscription: "sub_123"}
       )
     end
 
@@ -36,9 +36,9 @@ defmodule Stripe.InvoiceTest do
         :get,
         "/v1/invoices/upcoming",
         query: %{
-          :customer => "cust_123",
-          :"susbscription_items[][plan]" => "gold",
-          :"subscription_items[][quantity]" => 2
+          :customer => "cus_123",
+          :"subscription_items[0][plan]" => "gold",
+          :"subscription_items[0][quantity]" => 2
         }
       )
     end
@@ -66,12 +66,16 @@ defmodule Stripe.InvoiceTest do
   describe "pay/3" do
     test "pays an invoice" do
       {:ok, invoice} = Stripe.Invoice.retrieve("in_123")
+      assert_stripe_requested(:get, "/v1/invoices/#{invoice.id}")
+
       assert {:ok, %Stripe.Invoice{} = _paid_invoice} = Stripe.Invoice.pay(invoice, %{})
       assert_stripe_requested(:post, "/v1/invoices/#{invoice.id}/pay")
     end
 
     test "pays an invoice with a specific source" do
       {:ok, invoice} = Stripe.Invoice.retrieve("in_123")
+      assert_stripe_requested(:get, "/v1/invoices/#{invoice.id}")
+
       params = %{source: "src_123"}
       assert {:ok, %Stripe.Invoice{} = _paid_invoice} = Stripe.Invoice.pay(invoice, params)
 
@@ -91,6 +95,8 @@ defmodule Stripe.InvoiceTest do
   describe "void/2" do
     test "voids an invoice" do
       {:ok, invoice} = Stripe.Invoice.retrieve("in_123")
+      assert_stripe_requested(:get, "/v1/invoices/#{invoice.id}")
+
       assert {:ok, %Stripe.Invoice{} = _voided_invoice} = Stripe.Invoice.void(invoice)
       assert_stripe_requested(:post, "/v1/invoices/#{invoice.id}/void")
     end

--- a/test/stripe/subscriptions/invoiceitem_test.exs
+++ b/test/stripe/subscriptions/invoiceitem_test.exs
@@ -13,7 +13,7 @@ defmodule Stripe.InvoiceitemTest do
   describe "retrieve/2" do
     test "retrieves an invoice" do
       assert {:ok, %Stripe.Invoiceitem{}} = Stripe.Invoiceitem.retrieve("ii_1234")
-      assert_stripe_requested(:get, "/v1/invoiceitems/in_1234")
+      assert_stripe_requested(:get, "/v1/invoiceitems/ii_1234")
     end
   end
 
@@ -21,13 +21,15 @@ defmodule Stripe.InvoiceitemTest do
     test "updates an invoice" do
       params = %{metadata: %{key: "value"}}
       assert {:ok, %Stripe.Invoiceitem{}} = Stripe.Invoiceitem.update("ii_1234", params)
-      assert_stripe_requested(:post, "/v1/invoiceitems/in_1234")
+      assert_stripe_requested(:post, "/v1/invoiceitems/ii_1234")
     end
   end
 
   describe "delete/2" do
     test "deletes an invoice" do
       {:ok, invoiceitem} = Stripe.Invoiceitem.retrieve("ii_1234")
+      assert_stripe_requested(:get, "/v1/invoiceitems/#{invoiceitem.id}")
+
       assert {:ok, _} = Stripe.Invoiceitem.delete("ii_1234")
       assert_stripe_requested(:delete, "/v1/invoiceitems/#{invoiceitem.id}")
     end

--- a/test/stripe/subscriptions/plan_test.exs
+++ b/test/stripe/subscriptions/plan_test.exs
@@ -52,6 +52,8 @@ defmodule Stripe.PlanTest do
   describe "delete/2" do
     test "deletes a Plan" do
       {:ok, plan} = Stripe.Plan.retrieve("sapphire-elite")
+      assert_stripe_requested(:get, "/v1/plans/#{plan.id}")
+
       assert {:ok, %Stripe.Plan{}} = Stripe.Plan.delete(plan)
       assert_stripe_requested(:delete, "/v1/plans/#{plan.id}")
     end

--- a/test/stripe/subscriptions/product_test.exs
+++ b/test/stripe/subscriptions/product_test.exs
@@ -35,6 +35,8 @@ defmodule Stripe.ProductTest do
   describe "delete/1" do
     test "deletes a product" do
       {:ok, product} = Stripe.Product.retrieve("Plus")
+      assert_stripe_requested(:get, "/v1/products/#{product.id}")
+
       assert {:ok, _} = Stripe.Product.delete("Plus")
       assert_stripe_requested(:delete, "/v1/products/#{product.id}")
     end

--- a/test/stripe/subscriptions/subscription_item_test.exs
+++ b/test/stripe/subscriptions/subscription_item_test.exs
@@ -4,7 +4,7 @@ defmodule Stripe.SubscriptionItemTest do
   describe "retrieve/2" do
     test "retrieves a subscription" do
       assert {:ok, %Stripe.SubscriptionItem{}} = Stripe.SubscriptionItem.retrieve("sub_123")
-      assert_stripe_requested(:get, "/v1/subscriptions/sub_123")
+      assert_stripe_requested(:get, "/v1/subscription_items/sub_123")
     end
   end
 
@@ -21,25 +21,27 @@ defmodule Stripe.SubscriptionItemTest do
   end
 
   describe "update/2" do
-    test "updates a subscription" do
+    test "updates a subscription item" do
       params = %{metadata: %{foo: "bar"}}
-      assert {:ok, subscription} = Stripe.SubscriptionItem.update("sub_123", params)
-      assert_stripe_requested(:post, "/v1/subscriptions/#{subscription.id}")
+      assert {:ok, subscription_item} = Stripe.SubscriptionItem.update("sub_123", params)
+      assert_stripe_requested(:post, "/v1/subscription_items/#{subscription_item.id}")
     end
   end
 
   describe "delete/2" do
-    test "deletes a subscription" do
+    test "deletes a subscription item" do
       {:ok, subscription_item} = Stripe.SubscriptionItem.retrieve("sub_123")
+      assert_stripe_requested(:get, "/v1/subscription_items/#{subscription_item.id}")
+
       assert {:ok, %Stripe.SubscriptionItem{}} = Stripe.SubscriptionItem.delete("sub_123")
-      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription_item.id}")
+      assert_stripe_requested(:delete, "/v1/subscription_items/#{subscription_item.id}")
     end
   end
 
   describe "list/2" do
     test "lists all subscription_items" do
       assert {:ok, %Stripe.List{data: subscriptions}} = Stripe.SubscriptionItem.list("sub_123")
-      assert_stripe_requested(:get, "/v1/subscription_items")
+      assert_stripe_requested(:get, "/v1/subscription_items", query: %{subscription: "sub_123"})
       assert is_list(subscriptions)
       assert %Stripe.SubscriptionItem{} = hd(subscriptions)
     end

--- a/test/stripe/subscriptions/subscription_test.exs
+++ b/test/stripe/subscriptions/subscription_test.exs
@@ -81,7 +81,7 @@ defmodule Stripe.SubscriptionTest do
       assert subscription.cancel_at_period_end
 
       # The deprecated function acts as a facade for `cancel_at_period_end: true`.
-      assert_stripe_requested(:update, "/v1/subscriptions/#{subscription.id}")
+      assert_stripe_requested(:post, "/v1/subscriptions/#{subscription.id}")
     end
   end
 
@@ -91,7 +91,7 @@ defmodule Stripe.SubscriptionTest do
                Stripe.Subscription.delete("sub_123", %{at_period_end: true}, [])
 
       # The deprecated function acts as a facade for `cancel_at_period_end: true`.
-      assert_stripe_requested(:update, "/v1/subscriptions/sub_123")
+      assert_stripe_requested(:post, "/v1/subscriptions/sub_123")
     end
   end
 
@@ -107,6 +107,8 @@ defmodule Stripe.SubscriptionTest do
   describe "delete_discount/2" do
     test "deletes a subscription's discount" do
       {:ok, subscription} = Stripe.Subscription.retrieve("sub_123")
+      assert_stripe_requested(:get, "/v1/subscriptions/#{subscription.id}")
+
       assert {:ok, _} = Stripe.Subscription.delete_discount("sub_123")
       assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}/discount")
     end

--- a/test/stripe/subscriptions/usage_test.exs
+++ b/test/stripe/subscriptions/usage_test.exs
@@ -53,7 +53,7 @@ defmodule Stripe.SubscriptionItem.UsageTest do
       assert {:ok, %Stripe.List{data: usages}} =
                Stripe.SubscriptionItem.Usage.list(item_id, params)
 
-      assert_stripe_requested(:get, "/v1/subscription_items/#{item_id}/usage_record_summaries")
+      assert_stripe_requested(:get, "/v1/subscription_items/#{item_id}/usage_record_summaries?limit=10")
       assert is_list(usages)
       assert %{subscription_item: _sub_item_id} = hd(usages)
     end

--- a/test/support/stripe_case.ex
+++ b/test/support/stripe_case.ex
@@ -5,19 +5,74 @@ defmodule Stripe.StripeCase do
 
   use ExUnit.CaseTemplate
 
-  def assert_stripe_requested(_method, _url, _extra \\ []) do
-    # TODO: use something akin to WebMock to check the API calls are correct
-    assert true
+  def assert_stripe_requested(expected_method, path, extra \\ []) do
+    expected_url = build_url(path, Keyword.get(extra, :query))
+    expected_body = Keyword.get(extra, :body)
+    expected_headers = Keyword.get(extra, :headers)
+
+    assert_received({method, url, headers, body, _})
+
+    assert expected_method == method
+    assert expected_url == url
+
+    assert_stripe_request_body(expected_body, body)
+    assert_stripe_request_headers(expected_headers, headers)
   end
 
   def stripe_base_url() do
     Application.get_env(:stripity_stripe, :api_base_url)
   end
 
+  defp assert_stripe_request_headers(nil, _), do: nil
+
+  defp assert_stripe_request_headers(expected_headers, headers) when is_list(expected_headers) do
+    assert Enum.all?(expected_headers, &assert_stripe_request_headers(&1, headers))
+  end
+
+  defp assert_stripe_request_headers(expected_header, headers) do
+    assert Enum.any?(headers, fn header -> expected_header == header end),
+    """
+    Expected the header `#{inspect(expected_header)}` to be in the headers of the request.
+
+    Headers:
+    #{inspect(headers)}
+    """
+  end
+
+  defp assert_stripe_request_body(nil, _), do: nil
+
+  defp assert_stripe_request_body(expected_body, body) do
+
+    assert body == Stripe.URI.encode_query(expected_body)
+  end
+
+  defp build_url("/v1/" <> path, nil) do
+    stripe_base_url() <> path
+  end
+
+  defp build_url("/v1/" <> path, query_params) do
+    stripe_base_url() <> path <> "?" <> URI.encode_query(query_params)
+  end
+
+  defmodule HackneyMock do
+    @doc """
+    Send message to the owning process for each request so we can assert that
+    the request was made.
+
+    """
+    def request(method, path, headers, body, opts) do
+      send(self(), {method, path, headers, body, opts})
+
+      :hackney.request(method, path, headers, body, opts)
+    end
+  end
+
   using do
     quote do
       import Stripe.StripeCase,
         only: [assert_stripe_requested: 2, assert_stripe_requested: 3, stripe_base_url: 0]
+
+      Application.put_env(:stripity_stripe, :http_module, HackneyMock)
     end
   end
 end


### PR DESCRIPTION
The `assert_stripe_requested/3` function was not yet implemented.
To better test https://github.com/code-corps/stripity_stripe/pull/480#issuecomment-489315595 
I implemented this function to test whether the request was actually called. This is done by sending a message to the current process and asserting whether it was received and has the right shape.

The https://github.com/code-corps/stripity_stripe/commit/a1147ee720338b71bc393da5e970bad3164eb5ac commit was the only one where I found a bug in the current code. All other fixes only concern the tests where the wrong thing was asserted because of a typo or another mistake.

In the case where two requests are made in a test, it is necessary to assert both requests. Otherwise the `assert_stripe_requested/3` function might check the wrong request.

In a few cases the body, query_params or the request headers were also passed allong to `assert_stripe_requested/3`, these params are also asserted for being correct.