### PR TITLE
Enforce formatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ before_install:
       fi
   - export PATH=$PATH:$PWD/stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/
 script:
-  - mix format --check-formatted
+  - |
+      if [ "$TRAVIS_ELIXIR_VERSION" == "1.8" ]; then
+        mix format --dry-run --check-formatted; 
+      fi
   - mix coveralls.travis
   - MIX_ENV=dev mix dialyzer --halt-exit-status
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
       fi
   - export PATH=$PATH:$PWD/stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/
 script:
+  - mix format --check-formatted
   - mix coveralls.travis
   - MIX_ENV=dev mix dialyzer --halt-exit-status
 after_script:

--- a/lib/stripe/radar/review.ex
+++ b/lib/stripe/radar/review.ex
@@ -20,7 +20,7 @@ defmodule Stripe.Review do
           latitude: float,
           longitude: float,
           region: String.t()
-  }
+        }
 
   @type t :: %__MODULE__{
           id: Stripe.id(),

--- a/test/stripe/connect/transfer_reversal_test.exs
+++ b/test/stripe/connect/transfer_reversal_test.exs
@@ -16,8 +16,7 @@ defmodule Stripe.TransferReversalTest do
         amount: 123
       }
 
-      assert {:ok, %Stripe.TransferReversal{}} =
-               Stripe.TransferReversal.create("tr_123", params)
+      assert {:ok, %Stripe.TransferReversal{}} = Stripe.TransferReversal.create("tr_123", params)
 
       assert_stripe_requested(:post, "/v1/transfers/tr_123/reversals")
     end
@@ -26,7 +25,9 @@ defmodule Stripe.TransferReversalTest do
   describe "update/2" do
     test "updates a transfer" do
       params = %{metadata: %{foo: "bar"}}
-      assert {:ok, _transfer_reversal} = Stripe.TransferReversal.update("tr_123", "trr_456", params)
+
+      assert {:ok, _transfer_reversal} =
+               Stripe.TransferReversal.update("tr_123", "trr_456", params)
 
       assert_stripe_requested(:post, "/v1/transfers/tr_123/reversals/trr_456")
     end

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -61,13 +61,13 @@ defmodule Stripe.ConverterTest do
     expected_result = %Stripe.Event{
       account: "acct_445dwy73iNyGMfgu",
       api_version: "2019-02-19",
-      created: 1551702604,
+      created: 1_551_702_604,
       data: %{
         object: %Stripe.Review{
           billing_zip: nil,
           charge: "ch_1EAFvj73iNyGMfgutk44a8nD",
           closed_reason: nil,
-          created: 1551702603,
+          created: 1_551_702_603,
           id: "prv_1EAFvj73iNyGMfgu81yzEb0D",
           ip_address: "172.16.1.4",
           ip_address_location: %{
@@ -101,6 +101,7 @@ defmodule Stripe.ConverterTest do
       },
       type: "review.opened"
     }
+
     fixture = Helper.load_fixture("review_opened.json")
     result = Converter.convert_result(fixture)
 

--- a/test/stripe/subscriptions/usage_test.exs
+++ b/test/stripe/subscriptions/usage_test.exs
@@ -53,7 +53,11 @@ defmodule Stripe.SubscriptionItem.UsageTest do
       assert {:ok, %Stripe.List{data: usages}} =
                Stripe.SubscriptionItem.Usage.list(item_id, params)
 
-      assert_stripe_requested(:get, "/v1/subscription_items/#{item_id}/usage_record_summaries?limit=10")
+      assert_stripe_requested(
+        :get,
+        "/v1/subscription_items/#{item_id}/usage_record_summaries?limit=10"
+      )
+
       assert is_list(usages)
       assert %{subscription_item: _sub_item_id} = hd(usages)
     end

--- a/test/support/stripe_case.ex
+++ b/test/support/stripe_case.ex
@@ -31,18 +31,17 @@ defmodule Stripe.StripeCase do
 
   defp assert_stripe_request_headers(expected_header, headers) do
     assert Enum.any?(headers, fn header -> expected_header == header end),
-    """
-    Expected the header `#{inspect(expected_header)}` to be in the headers of the request.
+           """
+           Expected the header `#{inspect(expected_header)}` to be in the headers of the request.
 
-    Headers:
-    #{inspect(headers)}
-    """
+           Headers:
+           #{inspect(headers)}
+           """
   end
 
   defp assert_stripe_request_body(nil, _), do: nil
 
   defp assert_stripe_request_body(expected_body, body) do
-
     assert body == Stripe.URI.encode_query(expected_body)
   end
 


### PR DESCRIPTION
The Elixir formatter was applied several months ago (https://github.com/code-corps/stripity_stripe/commit/4d2f943dd4f300234a2bc88b5cf12f2531334493) but there was no check added in CI to ensure new commits are also properly formatted.

This PR reformats the code that was not properly formatted since the commit, and it adds a check in CI to error when a new commit introduces code that was not formatted.