### PR TITLE
Add tax_rate struct and api calls

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -49,6 +49,7 @@ defmodule Stripe.Converter do
     subscription
     subscription_item
     subscription_schedule
+    tax_rate
     transfer
     transfer_reversal
     token

--- a/lib/stripe/subscriptions/subscription_schedule.ex
+++ b/lib/stripe/subscriptions/subscription_schedule.ex
@@ -192,7 +192,7 @@ defmodule Stripe.SubscriptionSchedule do
   @doc """
   Releases a subscription schedule
 
-  Takes the subscription schedule `id.
+  Takes the subscription schedule `id`.
   """
 
   @spec release(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}

--- a/lib/stripe/subscriptions/tax_rate.ex
+++ b/lib/stripe/subscriptions/tax_rate.ex
@@ -1,0 +1,122 @@
+defmodule Stripe.TaxRate do
+  @moduledoc """
+  Work with Stripe TaxRate objects.
+
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          active: boolean,
+          created: Stripe.timestamp(),
+          description: String.t() | nil,
+          display_name: String.t() | nil,
+          inclusive: boolean,
+          jurisdiction: String.t() | nil,
+          livemode: boolean,
+          metadata: Stripe.Types.metadata(),
+          percentage: number | nil
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :active,
+    :created,
+    :description,
+    :display_name,
+    :inclusive,
+    :jurisdiction,
+    :livemode,
+    :metadata,
+    :percentage
+  ]
+
+  @plural_endpoint "tax_rates"
+
+  @doc """
+  Create a tax rate.
+  """
+  @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 :percentage => number,
+                 :display_name => String.t(),
+                 :inclusive => boolean,
+                 optional(:active) => boolean,
+                 optional(:description) => String.t(),
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:jurisdiction) => String.t()
+               }
+               | %{}
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> make_request()
+  end
+
+  @doc """
+  Retrieve a tax rate.
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Update a tax rate.
+
+  Takes the `id` and a map of changes.
+  """
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 :percentage => number,
+                 :display_name => String.t(),
+                 :inclusive => boolean,
+                 optional(:active) => boolean,
+                 optional(:description) => String.t(),
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:jurisdiction) => String.t()
+               }
+               | %{}
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  List all tax rates.
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:active) => boolean,
+                 optional(:created) => Stripe.date_query(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:limit) => 1..100,
+                 optional(:inclusive) => boolean,
+                 optional(:percentage) => number,
+                 optional(:starting_after) => t | Stripe.id()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/subscriptions/tax_rate.ex
+++ b/lib/stripe/subscriptions/tax_rate.ex
@@ -18,7 +18,7 @@ defmodule Stripe.TaxRate do
           jurisdiction: String.t() | nil,
           livemode: boolean,
           metadata: Stripe.Types.metadata(),
-          percentage: number
+          percentage: integer
         }
 
   defstruct [

--- a/lib/stripe/subscriptions/tax_rate.ex
+++ b/lib/stripe/subscriptions/tax_rate.ex
@@ -79,9 +79,9 @@ defmodule Stripe.TaxRate do
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
-                 :percentage => number,
-                 :display_name => String.t(),
-                 :inclusive => boolean,
+                 optional(:percentage) => number,
+                 optional(:display_name) => String.t(),
+                 optional(:inclusive) => boolean,
                  optional(:active) => boolean,
                  optional(:description) => String.t(),
                  optional(:metadata) => Stripe.Types.metadata(),

--- a/lib/stripe/subscriptions/tax_rate.ex
+++ b/lib/stripe/subscriptions/tax_rate.ex
@@ -13,12 +13,12 @@ defmodule Stripe.TaxRate do
           active: boolean,
           created: Stripe.timestamp(),
           description: String.t() | nil,
-          display_name: String.t() | nil,
+          display_name: String.t(),
           inclusive: boolean,
           jurisdiction: String.t() | nil,
           livemode: boolean,
           metadata: Stripe.Types.metadata(),
-          percentage: number | nil
+          percentage: number
         }
 
   defstruct [

--- a/mix.exs
+++ b/mix.exs
@@ -115,6 +115,7 @@ defmodule Stripe.Mixfile do
       ],
       Billing: [
         Stripe.Coupon,
+        Stripe.CreditNote,
         Stripe.Discount,
         Stripe.Invoice,
         Stripe.Invoiceitem,
@@ -123,7 +124,9 @@ defmodule Stripe.Mixfile do
         Stripe.Plan,
         Stripe.Subscription,
         Stripe.SubscriptionItem,
-        Stripe.SubscriptionItem.Usage
+        Stripe.SubscriptionItem.Usage,
+        Stripe.SubscriptionSchedule,
+        Stripe.TaxRate
       ],
       Connect: [
         Stripe.Account,

--- a/test/stripe/subscriptions/tax_rate_test.exs
+++ b/test/stripe/subscriptions/tax_rate_test.exs
@@ -1,0 +1,54 @@
+defmodule Stripe.TaxRateTest do
+  use Stripe.StripeCase, async: true
+
+  describe "create/2" do
+    test "creates a TaxRate for a customer" do
+      params = %{
+        display_name: "VAT",
+        description: "VAT Germany",
+        jurisdiction: "DE",
+        percentage: 19.0,
+        inclusive: false
+      }
+
+      assert {:ok, %Stripe.TaxRate{}} = Stripe.TaxRate.create(params)
+      assert_stripe_requested(:post, "/v1/tax_rates")
+    end
+
+    test "returns an error TaxRate" do
+      params = %{
+        display_name: "VAT",
+        description: "VAT Germany",
+        jurisdiction: "DE",
+        inclusive: false
+      }
+
+      assert {:error, %Stripe.Error{}} = Stripe.TaxRate.create(params)
+      assert_stripe_requested(:post, "/v1/tax_rates")
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a TaxRate" do
+      assert {:ok, %Stripe.TaxRate{}} = Stripe.TaxRate.retrieve("txr_1EXapq2eZvKYlo2CHmXqULaR")
+      assert_stripe_requested(:get, "/v1/tax_rates/txr_1EXapq2eZvKYlo2CHmXqULaR")
+    end
+  end
+
+  describe "update/2" do
+    test "updates a TaxRate" do
+      params = %{metadata: %{foo: "bar"}}
+      assert {:ok, plan} = Stripe.TaxRate.update("txr_1EXapq2eZvKYlo2CHmXqULaR", params)
+      assert_stripe_requested(:post, "/v1/tax_rates/#{plan.id}")
+    end
+  end
+
+  describe "list/2" do
+    test "lists all TaxRates" do
+      assert {:ok, %Stripe.List{data: plans}} = Stripe.TaxRate.list()
+      assert_stripe_requested(:get, "/v1/tax_rates")
+      assert is_list(plans)
+      assert %Stripe.TaxRate{} = hd(plans)
+    end
+  end
+end


### PR DESCRIPTION
See https://stripe.com/docs/api/tax_rates and https://stripe.com/docs/billing/migration/taxes#tax-percent-changes

TaxRates were added to Stripe, I've added them in this PR following the open api spec.