### PR TITLE
Add Stripe Issuing

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -30,6 +30,12 @@ defmodule Stripe.Converter do
     file
     invoice
     invoiceitem
+    issuing.authorization
+    issuing.card
+    issuing.card_details
+    issuing.cardholder
+    issuing.dispute
+    issuing.transaction
     line_item
     list
     oauth

--- a/lib/stripe/issuing/authorization.ex
+++ b/lib/stripe/issuing/authorization.ex
@@ -16,6 +16,22 @@ defmodule Stripe.Issuing.Authorization do
   use Stripe.Entity
   import Stripe.Request
 
+  @type request_history :: %{
+          approved: boolean,
+          authorized_amount: integer,
+          authorized_currency: String.t(),
+          created: Stripe.timestamp(),
+          held_amount: integer,
+          held_currency: String.t(),
+          reason: String.t()
+        }
+
+  @type verification_data :: %{
+          address_line1_check: String.t(),
+          address_zip_check: String.t(),
+          cvc_check: String.t()
+        }
+
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
@@ -31,14 +47,14 @@ defmodule Stripe.Issuing.Authorization do
           held_currency: String.t() | nil,
           is_held_amount_controllable: boolean,
           livemode: boolean,
-          merchant_data: Stripe.Types.merchant_data(),
+          merchant_data: Stripe.Issuing.Types.merchant_data(),
           metadata: Stripe.Types.metadata(),
           pending_authorized_amount: integer,
           pending_held_amount: integer,
-          request_history: Stripe.List.t(Stripe.Types.request_history()),
+          request_history: Stripe.List.t(request_history()),
           status: String.t(),
           transactions: Stripe.List.t(Stripe.Issuing.Transaction.t()),
-          verification_data: Stripe.Types.verification_data(),
+          verification_data: verification_data(),
           wallet_provider: String.t() | nil
         }
 

--- a/lib/stripe/issuing/authorization.ex
+++ b/lib/stripe/issuing/authorization.ex
@@ -1,0 +1,153 @@
+defmodule Stripe.Issuing.Authorization do
+  @moduledoc """
+  Work with Stripe Issuing authorization objects.
+
+  You can:
+
+  - Retrieve an authorization
+  - Update an authorization
+  - Approve an authorization
+  - Decline an authorization
+  - List all authorizations
+
+  Stripe API reference: https://stripe.com/docs/api/issuing/authorizations
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          approved: boolean,
+          authorization_method: String.t(),
+          authorized_amount: integer,
+          authorized_currency: String.t() | nil,
+          balance_transactions: Stripe.List.t(Stripe.BalanceTransaction.t()),
+          card: Stripe.Issuing.Card.t(),
+          cardholder: Stripe.id() | Stripe.Issuing.Cardholder.t(),
+          created: Stripe.timestamp(),
+          held_amount: integer,
+          held_currency: String.t() | nil,
+          is_held_amount_controllable: boolean,
+          livemode: boolean,
+          merchant_data: Stripe.Types.merchant_data(),
+          metadata: Stripe.Types.metadata(),
+          pending_authorized_amount: integer,
+          pending_held_amount: integer,
+          request_history: Stripe.List.t(Stripe.Types.request_history()),
+          status: String.t(),
+          transactions: Stripe.List.t(Stripe.Issuing.Transaction.t()),
+          verification_data: Stripe.Types.verification_data(),
+          wallet_provider: String.t() | nil
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :approved,
+    :authorization_method,
+    :authorized_amount,
+    :authorized_currency,
+    :balance_transactions,
+    :card,
+    :cardholder,
+    :created,
+    :held_amount,
+    :held_currency,
+    :is_held_amount_controllable,
+    :livemode,
+    :merchant_data,
+    :metadata,
+    :pending_authorized_amount,
+    :pending_held_amount,
+    :request_history,
+    :status,
+    :transactions,
+    :verification_data,
+    :wallet_provider
+  ]
+
+  @plural_endpoint "issuing/authorizations"
+
+  @doc """
+  Retrieve an authorization.
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Update an authorization.
+  """
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:metadata) => Stripe.Types.metadata(),
+              }
+              | %{}
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  Approve an authorization.
+  """
+  @spec approve(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:held_amount) => non_neg_integer
+              }
+              | %{}
+  def approve(id, params\\ %{}, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "/approve")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  Decline an authorization.
+  """
+  @spec decline(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def decline(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "/decline")
+    |> put_method(:post)
+    |> make_request()
+  end
+
+  @doc """
+  List all authorizations.
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:card) => Stripe.Issuing.Card.t() | Stripe.id(),
+                 optional(:cardholder) => Stripe.Issuing.Cardholder.t() | Stripe.id(),
+                 optional(:created) => String.t() | Stripe.date_query(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:limit) => 1..100,
+                 optional(:starting_after) => t | Stripe.id(),
+                 optional(:status) => String.t()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:card, :cardholder, :ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/issuing/authorization.ex
+++ b/lib/stripe/issuing/authorization.ex
@@ -102,10 +102,10 @@ defmodule Stripe.Issuing.Authorization do
   """
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:metadata) => Stripe.Types.metadata(),
-              }
-              | %{}
+               %{
+                 optional(:metadata) => Stripe.Types.metadata()
+               }
+               | %{}
   def update(id, params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
@@ -117,13 +117,14 @@ defmodule Stripe.Issuing.Authorization do
   @doc """
   Approve an authorization.
   """
-  @spec approve(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  @spec approve(Stripe.id() | t, params, Stripe.options()) ::
+          {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:held_amount) => non_neg_integer
-              }
-              | %{}
-  def approve(id, params\\ %{}, opts \\ []) do
+               %{
+                 optional(:held_amount) => non_neg_integer
+               }
+               | %{}
+  def approve(id, params \\ %{}, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "/approve")
     |> put_method(:post)

--- a/lib/stripe/issuing/card.ex
+++ b/lib/stripe/issuing/card.ex
@@ -22,7 +22,7 @@ defmodule Stripe.Issuing.Card do
           brand: String.t(),
           cardholder: Stripe.Issuing.Cardholder.t(),
           created: Stripe.timestamp(),
-          currency: String.t() | nil,
+          currency: String.t(),
           exp_month: pos_integer,
           exp_year: pos_integer,
           last4: String.t(),
@@ -33,7 +33,7 @@ defmodule Stripe.Issuing.Card do
           replacement_reason: String.t() | nil,
           shipping: Stripe.Types.shipping() | nil,
           status: String.t(),
-          type: String.t()
+          type: atom() | String.t()
         }
 
   defstruct [
@@ -65,6 +65,8 @@ defmodule Stripe.Issuing.Card do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 :currency => String.t(),
+                 :type => :physical | :virtual,
                  optional(:authorization_controls) =>
                    Stripe.Issuing.Types.authorization_controls(),
                  optional(:cardholder) => Stripe.Issuing.Cardholder.t(),

--- a/lib/stripe/issuing/card.ex
+++ b/lib/stripe/issuing/card.ex
@@ -64,16 +64,17 @@ defmodule Stripe.Issuing.Card do
   """
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
-                optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
-                optional(:metadata) => Stripe.Types.metadata(),
-                optional(:replacement_for) => t | Stripe.id(),
-                optional(:replacement_reason) => String.t(),
-                optional(:shipping) => Stripe.Types.shipping(),
-                optional(:status) => String.t()
-              }
-              | %{}
+               %{
+                 optional(:authorization_controls) =>
+                   Stripe.Issuing.Types.authorization_controls(),
+                 optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:replacement_for) => t | Stripe.id(),
+                 optional(:replacement_reason) => String.t(),
+                 optional(:shipping) => Stripe.Types.shipping(),
+                 optional(:status) => String.t()
+               }
+               | %{}
   def create(params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint)
@@ -98,16 +99,17 @@ defmodule Stripe.Issuing.Card do
   """
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
-                optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
-                optional(:metadata) => Stripe.Types.metadata(),
-                optional(:replacement_for) => t | Stripe.id(),
-                optional(:replacement_reason) => String.t(),
-                optional(:shipping) => Stripe.Types.shipping(),
-                optional(:status) => String.t()
-              }
-              | %{}
+               %{
+                 optional(:authorization_controls) =>
+                   Stripe.Issuing.Types.authorization_controls(),
+                 optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:replacement_for) => t | Stripe.id(),
+                 optional(:replacement_reason) => String.t(),
+                 optional(:shipping) => Stripe.Types.shipping(),
+                 optional(:status) => String.t()
+               }
+               | %{}
   def update(id, params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")

--- a/lib/stripe/issuing/card.ex
+++ b/lib/stripe/issuing/card.ex
@@ -18,7 +18,7 @@ defmodule Stripe.Issuing.Card do
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
-          authorization_controls: Stripe.Types.authorization_controls(),
+          authorization_controls: Stripe.Issuing.Types.authorization_controls(),
           brand: String.t(),
           cardholder: Stripe.Issuing.Cardholder.t(),
           created: Stripe.timestamp(),
@@ -65,7 +65,7 @@ defmodule Stripe.Issuing.Card do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
               %{
-                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
                 optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
                 optional(:metadata) => Stripe.Types.metadata(),
                 optional(:replacement_for) => t | Stripe.id(),
@@ -99,7 +99,7 @@ defmodule Stripe.Issuing.Card do
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
               %{
-                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
                 optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
                 optional(:metadata) => Stripe.Types.metadata(),
                 optional(:replacement_for) => t | Stripe.id(),

--- a/lib/stripe/issuing/card.ex
+++ b/lib/stripe/issuing/card.ex
@@ -1,0 +1,147 @@
+defmodule Stripe.Issuing.Card do
+  @moduledoc """
+  Work with Stripe Issuing card objects.
+
+  You can:
+
+  - Create a card
+  - Retrieve a card
+  - Update a card
+  - List all cards
+
+  Stripe API reference: https://stripe.com/docs/api/issuing/cards
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          authorization_controls: Stripe.Types.authorization_controls(),
+          brand: String.t(),
+          cardholder: Stripe.Issuing.Cardholder.t(),
+          created: Stripe.timestamp(),
+          currency: String.t() | nil,
+          exp_month: pos_integer,
+          exp_year: pos_integer,
+          last4: String.t(),
+          livemode: boolean,
+          metadata: Stripe.Types.metadata(),
+          name: String.t(),
+          replacement_for: t | Stripe.id() | nil,
+          replacement_reason: String.t() | nil,
+          shipping: Stripe.Types.shipping() | nil,
+          status: String.t(),
+          type: String.t()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :authorization_controls,
+    :brand,
+    :cardholder,
+    :created,
+    :currency,
+    :exp_month,
+    :exp_year,
+    :last4,
+    :livemode,
+    :metadata,
+    :name,
+    :replacement_for,
+    :replacement_reason,
+    :shipping,
+    :status,
+    :type
+  ]
+
+  @plural_endpoint "issuing/cards"
+
+  @doc """
+  Create a card.
+  """
+  @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
+                optional(:metadata) => Stripe.Types.metadata(),
+                optional(:replacement_for) => t | Stripe.id(),
+                optional(:replacement_reason) => String.t(),
+                optional(:shipping) => Stripe.Types.shipping(),
+                optional(:status) => String.t()
+              }
+              | %{}
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> make_request()
+  end
+
+  @doc """
+  Retrieve a card.
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Update a card.
+  """
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:cardholder) => Stripe.Issuing.Cardholder.t(),
+                optional(:metadata) => Stripe.Types.metadata(),
+                optional(:replacement_for) => t | Stripe.id(),
+                optional(:replacement_reason) => String.t(),
+                optional(:shipping) => Stripe.Types.shipping(),
+                optional(:status) => String.t()
+              }
+              | %{}
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  List all cards.
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:cardholder) => Stripe.Issuing.Cardholder.t() | Stripe.id(),
+                 optional(:created) => String.t() | Stripe.date_query(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:exp_month) => String.t(),
+                 optional(:exp_year) => String.t(),
+                 optional(:last4) => String.t(),
+                 optional(:limit) => 1..100,
+                 optional(:source) => String.t(),
+                 optional(:starting_after) => t | Stripe.id(),
+                 optional(:status) => String.t(),
+                 optional(:type) => String.t()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:cardholder, :ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/issuing/card_details.ex
+++ b/lib/stripe/issuing/card_details.ex
@@ -13,13 +13,13 @@ defmodule Stripe.Issuing.CardDetails do
   import Stripe.Request
 
   @type t :: %__MODULE__{
-    card: Stripe.Issuing.Card.t(),
-    object: String.t(),
-    cvc: String.t(),
-    exp_month: String.t(),
-    exp_year: String.t(),
-    number: String.t()
-  }
+          card: Stripe.Issuing.Card.t(),
+          object: String.t(),
+          cvc: String.t(),
+          exp_month: String.t(),
+          exp_year: String.t(),
+          number: String.t()
+        }
 
   defstruct [
     :card,
@@ -36,12 +36,11 @@ defmodule Stripe.Issuing.CardDetails do
   Retrieve card details.
   """
   @spec retrieve(Stripe.id() | Stripe.Issuing.Card.t(), Stripe.options()) ::
-    {:ok, t} | {:error, Stripe.Error.t()}
+          {:ok, t} | {:error, Stripe.Error.t()}
   def retrieve(id, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "/details")
     |> put_method(:get)
     |> make_request()
   end
-
 end

--- a/lib/stripe/issuing/card_details.ex
+++ b/lib/stripe/issuing/card_details.ex
@@ -1,0 +1,47 @@
+defmodule Stripe.Issuing.CardDetails do
+  @moduledoc """
+  Work with Stripe Issuing card details.
+
+  You can:
+
+  - Retrieve card details
+
+  Stripe API reference: https://stripe.com/docs/api/issuing/cards/retrieve_details
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+    card: Stripe.Issuing.Card.t(),
+    object: String.t(),
+    cvc: String.t(),
+    exp_month: String.t(),
+    exp_year: String.t(),
+    number: String.t()
+  }
+
+  defstruct [
+    :card,
+    :object,
+    :cvc,
+    :exp_month,
+    :exp_year,
+    :number
+  ]
+
+  @plural_endpoint "issuing/cards"
+
+  @doc """
+  Retrieve card details.
+  """
+  @spec retrieve(Stripe.id() | Stripe.Issuing.Card.t(), Stripe.options()) ::
+    {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "/details")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+end

--- a/lib/stripe/issuing/cardholder.ex
+++ b/lib/stripe/issuing/cardholder.ex
@@ -18,7 +18,7 @@ defmodule Stripe.Issuing.Cardholder do
           id: Stripe.id(),
           object: String.t(),
           authorization_controls: Stripe.Issuing.Types.authorization_controls() | nil,
-          billing: Stripe.Types.billing(),
+          billing: Stripe.Issuing.Types.billing(),
           created: Stripe.timestamp(),
           email: String.t() | nil,
           is_default: boolean | nil,

--- a/lib/stripe/issuing/cardholder.ex
+++ b/lib/stripe/issuing/cardholder.ex
@@ -27,7 +27,7 @@ defmodule Stripe.Issuing.Cardholder do
           name: String.t(),
           phone_number: String.t() | nil,
           status: String.t() | nil,
-          type: String.t()
+          type: atom() | String.t()
         }
 
   defstruct [
@@ -54,6 +54,9 @@ defmodule Stripe.Issuing.Cardholder do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 :billing => Stripe.Issuing.Types.billing(),
+                 :name => String.t(),
+                 :type => :individual | :business_entity,
                  optional(:authorization_controls) =>
                    Stripe.Issuing.Types.authorization_controls(),
                  optional(:email) => String.t(),

--- a/lib/stripe/issuing/cardholder.ex
+++ b/lib/stripe/issuing/cardholder.ex
@@ -1,0 +1,132 @@
+defmodule Stripe.Issuing.Cardholder do
+  @moduledoc """
+  Work with Stripe Issuing cardholder objects.
+
+  You can:
+
+  - Create a cardholder
+  - Retrieve a cardholder
+  - Update a cardholder
+
+  Stripe API reference: https://stripe.com/docs/api/issuing/cardholders
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          authorization_controls: Stripe.Types.authorization_controls() | nil,
+          billing: Stripe.Types.billing(),
+          created: Stripe.timestamp(),
+          email: String.t() | nil,
+          is_default: boolean | nil,
+          livemode: boolean,
+          metadata: Stripe.Types.metadata(),
+          name: String.t(),
+          phone_number: String.t() | nil,
+          status: String.t() | nil,
+          type: String.t()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :authorization_controls,
+    :billing,
+    :created,
+    :email,
+    :is_default,
+    :livemode,
+    :metadata,
+    :name,
+    :phone_number,
+    :status,
+    :type
+  ]
+
+  @plural_endpoint "issuing/cardholders"
+
+  @doc """
+  Create a cardholder.
+  """
+  @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:email) => String.t(),
+                optional(:is_default) => boolean,
+                optional(:metadata) => Stripe.Types.metadata(),
+                optional(:phone_number) => String.t(),
+                optional(:status) => String.t()
+              }
+              | %{}
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> make_request()
+  end
+
+  @doc """
+  Retrieve a cardholder.
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Update a cardholder.
+  """
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:email) => String.t(),
+                optional(:is_default) => boolean,
+                optional(:metadata) => Stripe.Types.metadata(),
+                optional(:phone_number) => String.t(),
+                optional(:status) => String.t()
+              }
+              | %{}
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  List all cardholders.
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:created) => String.t() | Stripe.date_query(),
+                 optional(:email) => String.t(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:is_default) => boolean,
+                 optional(:limit) => 1..100,
+                 optional(:phone_number) => String.t(),
+                 optional(:starting_after) => t | Stripe.id(),
+                 optional(:status) => String.t(),
+                 optional(:type) => String.t()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/issuing/cardholder.ex
+++ b/lib/stripe/issuing/cardholder.ex
@@ -17,7 +17,7 @@ defmodule Stripe.Issuing.Cardholder do
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
-          authorization_controls: Stripe.Types.authorization_controls() | nil,
+          authorization_controls: Stripe.Issuing.Types.authorization_controls() | nil,
           billing: Stripe.Types.billing(),
           created: Stripe.timestamp(),
           email: String.t() | nil,
@@ -54,7 +54,7 @@ defmodule Stripe.Issuing.Cardholder do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
               %{
-                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
                 optional(:email) => String.t(),
                 optional(:is_default) => boolean,
                 optional(:metadata) => Stripe.Types.metadata(),
@@ -87,7 +87,7 @@ defmodule Stripe.Issuing.Cardholder do
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
               %{
-                optional(:authorization_controls) => Stripe.Types.authorization_controls(),
+                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
                 optional(:email) => String.t(),
                 optional(:is_default) => boolean,
                 optional(:metadata) => Stripe.Types.metadata(),

--- a/lib/stripe/issuing/cardholder.ex
+++ b/lib/stripe/issuing/cardholder.ex
@@ -53,15 +53,16 @@ defmodule Stripe.Issuing.Cardholder do
   """
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
-                optional(:email) => String.t(),
-                optional(:is_default) => boolean,
-                optional(:metadata) => Stripe.Types.metadata(),
-                optional(:phone_number) => String.t(),
-                optional(:status) => String.t()
-              }
-              | %{}
+               %{
+                 optional(:authorization_controls) =>
+                   Stripe.Issuing.Types.authorization_controls(),
+                 optional(:email) => String.t(),
+                 optional(:is_default) => boolean,
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:phone_number) => String.t(),
+                 optional(:status) => String.t()
+               }
+               | %{}
   def create(params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint)
@@ -86,15 +87,16 @@ defmodule Stripe.Issuing.Cardholder do
   """
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:authorization_controls) => Stripe.Issuing.Types.authorization_controls(),
-                optional(:email) => String.t(),
-                optional(:is_default) => boolean,
-                optional(:metadata) => Stripe.Types.metadata(),
-                optional(:phone_number) => String.t(),
-                optional(:status) => String.t()
-              }
-              | %{}
+               %{
+                 optional(:authorization_controls) =>
+                   Stripe.Issuing.Types.authorization_controls(),
+                 optional(:email) => String.t(),
+                 optional(:is_default) => boolean,
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:phone_number) => String.t(),
+                 optional(:status) => String.t()
+               }
+               | %{}
   def update(id, params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")

--- a/lib/stripe/issuing/dispute.ex
+++ b/lib/stripe/issuing/dispute.ex
@@ -35,7 +35,7 @@ defmodule Stripe.Issuing.Dispute do
           evidence: evidence(),
           livemode: boolean,
           metadata: Stripe.Types.metadata(),
-          reason: String.t(),
+          reason: atom() | String.t(),
           status: String.t()
         }
 
@@ -61,6 +61,8 @@ defmodule Stripe.Issuing.Dispute do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 :disputed_transaction => Stripe.id() | Stripe.Issuing.Transaction.t(),
+                 :reason => :other | :fradulent,
                  optional(:amount) => non_neg_integer,
                  optional(:evidence) => evidence(),
                  optional(:metadata) => Stripe.Types.metadata()
@@ -71,6 +73,7 @@ defmodule Stripe.Issuing.Dispute do
     |> put_endpoint(@plural_endpoint)
     |> put_params(params)
     |> put_method(:post)
+    |> cast_to_id([:disputed_transaction])
     |> make_request()
   end
 

--- a/lib/stripe/issuing/dispute.ex
+++ b/lib/stripe/issuing/dispute.ex
@@ -15,6 +15,16 @@ defmodule Stripe.Issuing.Dispute do
   use Stripe.Entity
   import Stripe.Request
 
+  @type evidence :: %{
+          fraudulent: evidence_detail() | nil,
+          other: evidence_detail() | nil
+        }
+
+  @type evidence_detail :: %{
+          dispute_explanation: String.t(),
+          uncategorized_file: String.t()
+        }
+
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
@@ -22,7 +32,7 @@ defmodule Stripe.Issuing.Dispute do
           created: Stripe.timestamp(),
           currency: String.t() | nil,
           disputed_transaction: Stripe.id() | Stripe.Issuing.Transaction.t(),
-          evidence: Stripe.Types.evidence(),
+          evidence: evidence(),
           livemode: boolean,
           metadata: Stripe.Types.metadata(),
           reason: String.t(),
@@ -52,7 +62,7 @@ defmodule Stripe.Issuing.Dispute do
         when params:
               %{
                 optional(:amount) => non_neg_integer,
-                optional(:evidence) => Stripe.Types.evidence(),
+                optional(:evidence) => evidence(),
                 optional(:metadata) => Stripe.Types.metadata(),
               }
               | %{}

--- a/lib/stripe/issuing/dispute.ex
+++ b/lib/stripe/issuing/dispute.ex
@@ -1,0 +1,117 @@
+defmodule Stripe.Issuing.Dispute do
+  @moduledoc """
+  Work with Stripe Issuing dispute objects.
+
+  You can:
+
+  - Create a dispute
+  - Retrieve a dispute
+  - Update a dispute
+  - List all disputes
+
+  Stripe API reference: https://stripe.com/docs/api/issuing/disputes
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          amount: integer,
+          created: Stripe.timestamp(),
+          currency: String.t() | nil,
+          disputed_transaction: Stripe.id() | Stripe.Issuing.Transaction.t(),
+          evidence: Stripe.Types.evidence(),
+          livemode: boolean,
+          metadata: Stripe.Types.metadata(),
+          reason: String.t(),
+          status: String.t()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :created,
+    :currency,
+    :disputed_transaction,
+    :evidence,
+    :livemode,
+    :metadata,
+    :reason,
+    :status
+  ]
+
+  @plural_endpoint "issuing/disputes"
+
+  @doc """
+  Create a dispute.
+  """
+  @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:amount) => non_neg_integer,
+                optional(:evidence) => Stripe.Types.evidence(),
+                optional(:metadata) => Stripe.Types.metadata(),
+              }
+              | %{}
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> make_request()
+  end
+
+  @doc """
+  Retrieve a dispute.
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Update a dispute.
+  """
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:metadata) => Stripe.Types.metadata()
+              }
+              | %{}
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  List all disputes.
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:created) => String.t() | Stripe.date_query(),
+                 optional(:disputed_transaction) => Stripe.Issuing.Transaction.t() | Stripe.id(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:limit) => 1..100,
+                 optional(:starting_after) => t | Stripe.id()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:disputed_transaction, :ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/issuing/dispute.ex
+++ b/lib/stripe/issuing/dispute.ex
@@ -60,12 +60,12 @@ defmodule Stripe.Issuing.Dispute do
   """
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:amount) => non_neg_integer,
-                optional(:evidence) => evidence(),
-                optional(:metadata) => Stripe.Types.metadata(),
-              }
-              | %{}
+               %{
+                 optional(:amount) => non_neg_integer,
+                 optional(:evidence) => evidence(),
+                 optional(:metadata) => Stripe.Types.metadata()
+               }
+               | %{}
   def create(params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint)
@@ -90,10 +90,10 @@ defmodule Stripe.Issuing.Dispute do
   """
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:metadata) => Stripe.Types.metadata()
-              }
-              | %{}
+               %{
+                 optional(:metadata) => Stripe.Types.metadata()
+               }
+               | %{}
   def update(id, params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")

--- a/lib/stripe/issuing/transaction.ex
+++ b/lib/stripe/issuing/transaction.ex
@@ -26,7 +26,7 @@ defmodule Stripe.Issuing.Transaction do
           currency: String.t() | nil,
           dispute: Stripe.id() | Stripe.Issuing.Dispute.t(),
           livemode: boolean,
-          merchant_data: Stripe.Types.merchant_data(),
+          merchant_data: Stripe.Issuing.Types.merchant_data(),
           metadata: Stripe.Types.metadata(),
           type: String.t()
         }

--- a/lib/stripe/issuing/transaction.ex
+++ b/lib/stripe/issuing/transaction.ex
@@ -66,10 +66,10 @@ defmodule Stripe.Issuing.Transaction do
   """
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
-              %{
-                optional(:metadata) => Stripe.Types.metadata()
-              }
-              | %{}
+               %{
+                 optional(:metadata) => Stripe.Types.metadata()
+               }
+               | %{}
   def update(id, params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")

--- a/lib/stripe/issuing/transaction.ex
+++ b/lib/stripe/issuing/transaction.ex
@@ -1,0 +1,106 @@
+defmodule Stripe.Issuing.Transaction do
+  @moduledoc """
+  Work with Stripe Issuing transaction objects.
+
+  You can:
+
+  - Retrieve a transaction
+  - Update a transaction
+  - List all transactions
+
+  Stripe API reference: https://stripe.com/docs/api/issuing/transactions
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          amount: integer,
+          authorization: Stripe.id() | Stripe.Issuing.Authorization.t(),
+          balance_transaction: String.t(),
+          card: Stripe.id() | Stripe.Issuing.Card.t(),
+          cardholder: Stripe.id() | Stripe.Issuing.Cardholder.t(),
+          created: Stripe.timestamp(),
+          currency: String.t() | nil,
+          dispute: Stripe.id() | Stripe.Issuing.Dispute.t(),
+          livemode: boolean,
+          merchant_data: Stripe.Types.merchant_data(),
+          metadata: Stripe.Types.metadata(),
+          type: String.t()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :amount,
+    :authorization,
+    :balance_transaction,
+    :card,
+    :cardholder,
+    :created,
+    :currency,
+    :dispute,
+    :livemode,
+    :merchant_data,
+    :metadata,
+    :type
+  ]
+
+  @plural_endpoint "issuing/transactions"
+
+  @doc """
+  Retrieve a transaction.
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Update a transaction.
+  """
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+              %{
+                optional(:metadata) => Stripe.Types.metadata()
+              }
+              | %{}
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  List all transactions.
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:card) => Stripe.Issuing.Card.t() | Stripe.id(),
+                 optional(:cardholder) => Stripe.Issuing.Cardholder.t() | Stripe.id(),
+                 optional(:created) => String.t() | Stripe.date_query(),
+                 optional(:dispute) => Stripe.Issuing.Dispute.t() | Stripe.id(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:limit) => 1..100,
+                 optional(:settlement) => String.t(),
+                 optional(:starting_after) => t | Stripe.id()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:card, :cardholder, :dispute, :ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/issuing/types.ex
+++ b/lib/stripe/issuing/types.ex
@@ -12,6 +12,11 @@ defmodule Stripe.Issuing.Types do
           max_approvals: non_neg_integer | nil
         }
 
+  @type billing :: %{
+          address: Stripe.Types.address(),
+          name: String.t()
+        }
+
   @type merchant_data :: %{
           category: String.t(),
           city: String.t(),

--- a/lib/stripe/issuing/types.ex
+++ b/lib/stripe/issuing/types.ex
@@ -32,5 +32,4 @@ defmodule Stripe.Issuing.Types do
           categories: list(),
           interval: String.t()
         }
-
 end

--- a/lib/stripe/issuing/types.ex
+++ b/lib/stripe/issuing/types.ex
@@ -1,0 +1,31 @@
+defmodule Stripe.Issuing.Types do
+  @moduledoc """
+  A module that contains shared issuing types matching Stripe schemas.
+  """
+
+  @type authorization_controls :: %{
+          allowed_categories: list() | nil,
+          blocked_categories: list() | nil,
+          spending_limits: list(spending_limits()) | nil,
+          currency: String.t() | nil,
+          max_amount: non_neg_integer | nil,
+          max_approvals: non_neg_integer | nil
+        }
+
+  @type merchant_data :: %{
+          category: String.t(),
+          city: String.t(),
+          country: String.t(),
+          name: String.t(),
+          network_id: String.t(),
+          postal_code: String.t(),
+          state: String.t()
+        }
+
+  @type spending_limits :: %{
+          amount: non_neg_integer,
+          categories: list(),
+          interval: String.t()
+        }
+
+end

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -12,6 +12,30 @@ defmodule Stripe.Types do
           state: String.t() | nil
         }
 
+  @type authorization_controls :: %{
+          allowed_categories: list() | nil,
+          blocked_categories: list() | nil,
+          spending_limits: list(Stripe.Types.spending_limits()) | nil,
+          currency: String.t() | nil,
+          max_amount: non_neg_integer | nil,
+          max_approvals: non_neg_integer | nil
+        }
+
+  @type billing :: %{
+          address: Stripe.Types.address(),
+          name: String.t()
+        }
+
+  @type evidence :: %{
+          fraudulent: Stripe.Types.evidence_detail() | nil,
+          other: Stripe.Types.evidence_detail() | nil
+        }
+
+  @type evidence_detail :: %{
+          dispute_explanation: String.t(),
+          uncategorized_file: String.t()
+        }
+
   @type fee :: %{
           amount: integer,
           application: String.t() | nil,
@@ -20,16 +44,45 @@ defmodule Stripe.Types do
           type: String.t()
         }
 
+  @type merchant_data :: %{
+          category: String.t(),
+          city: String.t(),
+          country: String.t(),
+          name: String.t(),
+          network_id: String.t(),
+          postal_code: String.t(),
+          state: String.t()
+        }
+
   @type metadata :: %{
           optional(String.t()) => String.t()
+        }
+
+  @type request_history :: %{
+          approved: boolean,
+          authorized_amount: integer,
+          authorized_currency: String.t(),
+          created: Stripe.timestamp(),
+          held_amount: integer,
+          held_currency: String.t(),
+          reason: String.t()
         }
 
   @type shipping :: %{
           address: Stripe.Types.address(),
           carrier: String.t() | nil,
+          eta: Stripe.timestamp() | nil,
           name: String.t(),
           phone: String.t() | nil,
-          tracking_number: String.t() | nil
+          status: String.t() | nil,
+          tracking_number: String.t() | nil,
+          tracking_url: String.t() | nil
+        }
+
+  @type spending_limits :: %{
+          amount: non_neg_integer,
+          categories: list(),
+          interval: String.t()
         }
 
   @type tax_info :: %{
@@ -47,5 +100,11 @@ defmodule Stripe.Types do
           interval: String.t(),
           monthly_anchor: non_neg_integer | nil,
           weekly_anchor: String.t() | nil
+        }
+
+  @type verification_data :: %{
+          address_line1_check: String.t(),
+          address_zip_check: String.t(),
+          cvc_check: String.t()
         }
 end

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -12,28 +12,9 @@ defmodule Stripe.Types do
           state: String.t() | nil
         }
 
-  @type authorization_controls :: %{
-          allowed_categories: list() | nil,
-          blocked_categories: list() | nil,
-          spending_limits: list(Stripe.Types.spending_limits()) | nil,
-          currency: String.t() | nil,
-          max_amount: non_neg_integer | nil,
-          max_approvals: non_neg_integer | nil
-        }
-
   @type billing :: %{
           address: Stripe.Types.address(),
           name: String.t()
-        }
-
-  @type evidence :: %{
-          fraudulent: Stripe.Types.evidence_detail() | nil,
-          other: Stripe.Types.evidence_detail() | nil
-        }
-
-  @type evidence_detail :: %{
-          dispute_explanation: String.t(),
-          uncategorized_file: String.t()
         }
 
   @type fee :: %{
@@ -44,28 +25,8 @@ defmodule Stripe.Types do
           type: String.t()
         }
 
-  @type merchant_data :: %{
-          category: String.t(),
-          city: String.t(),
-          country: String.t(),
-          name: String.t(),
-          network_id: String.t(),
-          postal_code: String.t(),
-          state: String.t()
-        }
-
   @type metadata :: %{
           optional(String.t()) => String.t()
-        }
-
-  @type request_history :: %{
-          approved: boolean,
-          authorized_amount: integer,
-          authorized_currency: String.t(),
-          created: Stripe.timestamp(),
-          held_amount: integer,
-          held_currency: String.t(),
-          reason: String.t()
         }
 
   @type shipping :: %{
@@ -77,12 +38,6 @@ defmodule Stripe.Types do
           status: String.t() | nil,
           tracking_number: String.t() | nil,
           tracking_url: String.t() | nil
-        }
-
-  @type spending_limits :: %{
-          amount: non_neg_integer,
-          categories: list(),
-          interval: String.t()
         }
 
   @type tax_info :: %{
@@ -102,9 +57,4 @@ defmodule Stripe.Types do
           weekly_anchor: String.t() | nil
         }
 
-  @type verification_data :: %{
-          address_line1_check: String.t(),
-          address_zip_check: String.t(),
-          cvc_check: String.t()
-        }
 end

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -12,11 +12,6 @@ defmodule Stripe.Types do
           state: String.t() | nil
         }
 
-  @type billing :: %{
-          address: Stripe.Types.address(),
-          name: String.t()
-        }
-
   @type fee :: %{
           amount: integer,
           application: String.t() | nil,

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -51,5 +51,4 @@ defmodule Stripe.Types do
           monthly_anchor: non_neg_integer | nil,
           weekly_anchor: String.t() | nil
         }
-
 end

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -53,6 +53,12 @@ defmodule Stripe.Util do
   @spec object_name_to_module(String.t()) :: module
   def object_name_to_module("checkout.session"), do: Stripe.Session
   def object_name_to_module("file"), do: Stripe.FileUpload
+  def object_name_to_module("issuing.authorization"), do: Stripe.Issuing.Authorization
+  def object_name_to_module("issuing.card"), do: Stripe.Issuing.Card
+  def object_name_to_module("issuing.card_details"), do: Stripe.Issuing.CardDetails
+  def object_name_to_module("issuing.cardholder"), do: Stripe.Issuing.Cardholder
+  def object_name_to_module("issuing.dispute"), do: Stripe.Issuing.Dispute
+  def object_name_to_module("issuing.transaction"), do: Stripe.Issuing.Transaction
 
   def object_name_to_module(object_name) do
     module_name =

--- a/test/stripe/issuing/authorization_test.exs
+++ b/test/stripe/issuing/authorization_test.exs
@@ -3,26 +3,31 @@ defmodule Stripe.Issuing.AuthorizationTest do
 
   test "is retrievable" do
     assert {:ok, %Stripe.Issuing.Authorization{}} =
-      Stripe.Issuing.Authorization.retrieve("iauth_123")
+             Stripe.Issuing.Authorization.retrieve("iauth_123")
+
     assert_stripe_requested(:get, "/v1/issuing/authorizations/iauth_123")
   end
 
   test "is updateable" do
     params = %{metadata: %{key: "value"}}
+
     assert {:ok, %Stripe.Issuing.Authorization{}} =
-      Stripe.Issuing.Authorization.update("iauth_123", params)
+             Stripe.Issuing.Authorization.update("iauth_123", params)
+
     assert_stripe_requested(:post, "/v1/issuing/authorizations/iauth_123")
   end
 
   test "is approvable" do
     assert {:ok, %Stripe.Issuing.Authorization{}} =
-      Stripe.Issuing.Authorization.approve("iauth_123")
+             Stripe.Issuing.Authorization.approve("iauth_123")
+
     assert_stripe_requested(:post, "/v1/issuing/authorizations/iauth_123/approve")
   end
 
   test "is declinable" do
     assert {:ok, %Stripe.Issuing.Authorization{}} =
-      Stripe.Issuing.Authorization.decline("iauth_123")
+             Stripe.Issuing.Authorization.decline("iauth_123")
+
     assert_stripe_requested(:post, "/v1/issuing/authorizations/iauth_123/decline")
   end
 

--- a/test/stripe/issuing/authorization_test.exs
+++ b/test/stripe/issuing/authorization_test.exs
@@ -1,0 +1,35 @@
+defmodule Stripe.Issuing.AuthorizationTest do
+  use Stripe.StripeCase, async: true
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.Issuing.Authorization{}} =
+      Stripe.Issuing.Authorization.retrieve("iauth_123")
+    assert_stripe_requested(:get, "/v1/issuing/authorizations/iauth_123")
+  end
+
+  test "is updateable" do
+    params = %{metadata: %{key: "value"}}
+    assert {:ok, %Stripe.Issuing.Authorization{}} =
+      Stripe.Issuing.Authorization.update("iauth_123", params)
+    assert_stripe_requested(:post, "/v1/issuing/authorizations/iauth_123")
+  end
+
+  test "is approvable" do
+    assert {:ok, %Stripe.Issuing.Authorization{}} =
+      Stripe.Issuing.Authorization.approve("iauth_123")
+    assert_stripe_requested(:post, "/v1/issuing/authorizations/iauth_123/approve")
+  end
+
+  test "is declinable" do
+    assert {:ok, %Stripe.Issuing.Authorization{}} =
+      Stripe.Issuing.Authorization.decline("iauth_123")
+    assert_stripe_requested(:post, "/v1/issuing/authorizations/iauth_123/decline")
+  end
+
+  test "is listable" do
+    assert {:ok, %Stripe.List{data: authorizations}} = Stripe.Issuing.Authorization.list()
+    assert_stripe_requested(:get, "/v1/issuing/authorizations")
+    assert is_list(authorizations)
+    assert %Stripe.Issuing.Authorization{} = hd(authorizations)
+  end
+end

--- a/test/stripe/issuing/card_details_test.exs
+++ b/test/stripe/issuing/card_details_test.exs
@@ -1,0 +1,8 @@
+defmodule Stripe.Issuing.CardDetailsTest do
+  use Stripe.StripeCase, async: true
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.Issuing.CardDetails{}} = Stripe.Issuing.CardDetails.retrieve("ic_123")
+    assert_stripe_requested(:get, "/v1/issuing/cards/ic_123/details")
+  end
+end

--- a/test/stripe/issuing/card_test.exs
+++ b/test/stripe/issuing/card_test.exs
@@ -7,8 +7,7 @@ defmodule Stripe.Issuing.CardTest do
       type: "virtual"
     }
 
-    assert {:ok, %Stripe.Issuing.Card{}} =
-      Stripe.Issuing.Card.create(params)
+    assert {:ok, %Stripe.Issuing.Card{}} = Stripe.Issuing.Card.create(params)
 
     assert_stripe_requested(:post, "/v1/issuing/cards")
   end
@@ -20,8 +19,7 @@ defmodule Stripe.Issuing.CardTest do
 
   test "is updateable" do
     params = %{metadata: %{key: "value"}}
-    assert {:ok, %Stripe.Issuing.Card{}} =
-      Stripe.Issuing.Card.update("ic_123", params)
+    assert {:ok, %Stripe.Issuing.Card{}} = Stripe.Issuing.Card.update("ic_123", params)
     assert_stripe_requested(:post, "/v1/issuing/cards/ic_123")
   end
 

--- a/test/stripe/issuing/card_test.exs
+++ b/test/stripe/issuing/card_test.exs
@@ -4,7 +4,7 @@ defmodule Stripe.Issuing.CardTest do
   test "is creatable" do
     params = %{
       currency: "usd",
-      type: "virtual"
+      type: :virtual
     }
 
     assert {:ok, %Stripe.Issuing.Card{}} = Stripe.Issuing.Card.create(params)

--- a/test/stripe/issuing/card_test.exs
+++ b/test/stripe/issuing/card_test.exs
@@ -1,0 +1,34 @@
+defmodule Stripe.Issuing.CardTest do
+  use Stripe.StripeCase, async: true
+
+  test "is creatable" do
+    params = %{
+      currency: "usd",
+      type: "virtual"
+    }
+
+    assert {:ok, %Stripe.Issuing.Card{}} =
+      Stripe.Issuing.Card.create(params)
+
+    assert_stripe_requested(:post, "/v1/issuing/cards")
+  end
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.Issuing.Card{}} = Stripe.Issuing.Card.retrieve("ic_123")
+    assert_stripe_requested(:get, "/v1/issuing/cards/ic_123")
+  end
+
+  test "is updateable" do
+    params = %{metadata: %{key: "value"}}
+    assert {:ok, %Stripe.Issuing.Card{}} =
+      Stripe.Issuing.Card.update("ic_123", params)
+    assert_stripe_requested(:post, "/v1/issuing/cards/ic_123")
+  end
+
+  test "is listable" do
+    assert {:ok, %Stripe.List{data: cards}} = Stripe.Issuing.Card.list()
+    assert_stripe_requested(:get, "/v1/issuing/cards")
+    assert is_list(cards)
+    assert %Stripe.Issuing.Card{} = hd(cards)
+  end
+end

--- a/test/stripe/issuing/cardholder_test.exs
+++ b/test/stripe/issuing/cardholder_test.exs
@@ -17,8 +17,7 @@ defmodule Stripe.Issuing.CardholderTest do
       }
     }
 
-    assert {:ok, %Stripe.Issuing.Cardholder{}} =
-      Stripe.Issuing.Cardholder.create(params)
+    assert {:ok, %Stripe.Issuing.Cardholder{}} = Stripe.Issuing.Cardholder.create(params)
 
     assert_stripe_requested(:post, "/v1/issuing/cardholders")
   end
@@ -30,8 +29,10 @@ defmodule Stripe.Issuing.CardholderTest do
 
   test "is updateable" do
     params = %{metadata: %{key: "value"}}
+
     assert {:ok, %Stripe.Issuing.Cardholder{}} =
-      Stripe.Issuing.Cardholder.update("ich_123", params)
+             Stripe.Issuing.Cardholder.update("ich_123", params)
+
     assert_stripe_requested(:post, "/v1/issuing/cardholders/ich_123")
   end
 

--- a/test/stripe/issuing/cardholder_test.exs
+++ b/test/stripe/issuing/cardholder_test.exs
@@ -1,0 +1,44 @@
+defmodule Stripe.Issuing.CardholderTest do
+  use Stripe.StripeCase, async: true
+
+  test "is creatable" do
+    params = %{
+      name: "Jenny Rosen",
+      type: :individual,
+      billing: %{
+        address: %{
+          line1: "123 Fake St",
+          line2: "Apt 3",
+          city: "Beverly Hills",
+          state: "CA",
+          postal_code: "90210",
+          country: "US"
+        }
+      }
+    }
+
+    assert {:ok, %Stripe.Issuing.Cardholder{}} =
+      Stripe.Issuing.Cardholder.create(params)
+
+    assert_stripe_requested(:post, "/v1/issuing/cardholders")
+  end
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.Issuing.Cardholder{}} = Stripe.Issuing.Cardholder.retrieve("ich_123")
+    assert_stripe_requested(:get, "/v1/issuing/cardholders/ich_123")
+  end
+
+  test "is updateable" do
+    params = %{metadata: %{key: "value"}}
+    assert {:ok, %Stripe.Issuing.Cardholder{}} =
+      Stripe.Issuing.Cardholder.update("ich_123", params)
+    assert_stripe_requested(:post, "/v1/issuing/cardholders/ich_123")
+  end
+
+  test "is listable" do
+    assert {:ok, %Stripe.List{data: cardholders}} = Stripe.Issuing.Cardholder.list()
+    assert_stripe_requested(:get, "/v1/issuing/cardholders")
+    assert is_list(cardholders)
+    assert %Stripe.Issuing.Cardholder{} = hd(cardholders)
+  end
+end

--- a/test/stripe/issuing/dispute_test.exs
+++ b/test/stripe/issuing/dispute_test.exs
@@ -7,8 +7,7 @@ defmodule Stripe.Issuing.DisputeTest do
       reason: :fraudulent
     }
 
-    assert {:ok, %Stripe.Issuing.Dispute{}} =
-      Stripe.Issuing.Dispute.create(params)
+    assert {:ok, %Stripe.Issuing.Dispute{}} = Stripe.Issuing.Dispute.create(params)
 
     assert_stripe_requested(:post, "/v1/issuing/disputes")
   end
@@ -20,8 +19,7 @@ defmodule Stripe.Issuing.DisputeTest do
 
   test "is updateable" do
     params = %{metadata: %{key: "value"}}
-    assert {:ok, %Stripe.Issuing.Dispute{}} =
-      Stripe.Issuing.Dispute.update("idp_123", params)
+    assert {:ok, %Stripe.Issuing.Dispute{}} = Stripe.Issuing.Dispute.update("idp_123", params)
     assert_stripe_requested(:post, "/v1/issuing/disputes/idp_123")
   end
 

--- a/test/stripe/issuing/dispute_test.exs
+++ b/test/stripe/issuing/dispute_test.exs
@@ -1,0 +1,34 @@
+defmodule Stripe.Issuing.DisputeTest do
+  use Stripe.StripeCase, async: true
+
+  test "is creatable" do
+    params = %{
+      disputed_transaction: "ipi_123",
+      reason: :fraudulent
+    }
+
+    assert {:ok, %Stripe.Issuing.Dispute{}} =
+      Stripe.Issuing.Dispute.create(params)
+
+    assert_stripe_requested(:post, "/v1/issuing/disputes")
+  end
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.Issuing.Dispute{}} = Stripe.Issuing.Dispute.retrieve("idp_123")
+    assert_stripe_requested(:get, "/v1/issuing/disputes/idp_123")
+  end
+
+  test "is updateable" do
+    params = %{metadata: %{key: "value"}}
+    assert {:ok, %Stripe.Issuing.Dispute{}} =
+      Stripe.Issuing.Dispute.update("idp_123", params)
+    assert_stripe_requested(:post, "/v1/issuing/disputes/idp_123")
+  end
+
+  test "is listable" do
+    assert {:ok, %Stripe.List{data: disputes}} = Stripe.Issuing.Dispute.list()
+    assert_stripe_requested(:get, "/v1/issuing/disputes")
+    assert is_list(disputes)
+    assert %Stripe.Issuing.Dispute{} = hd(disputes)
+  end
+end

--- a/test/stripe/issuing/transaction_test.exs
+++ b/test/stripe/issuing/transaction_test.exs
@@ -1,0 +1,22 @@
+defmodule Stripe.Issuing.TransactionTest do
+  use Stripe.StripeCase, async: true
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.Issuing.Transaction{}} = Stripe.Issuing.Transaction.retrieve("ipi_123")
+    assert_stripe_requested(:get, "/v1/issuing/transactions/ipi_123")
+  end
+
+  test "is updateable" do
+    params = %{metadata: %{key: "value"}}
+    assert {:ok, %Stripe.Issuing.Transaction{}} =
+      Stripe.Issuing.Transaction.update("ipi_123", params)
+    assert_stripe_requested(:post, "/v1/issuing/transactions/ipi_123")
+  end
+
+  test "is listable" do
+    assert {:ok, %Stripe.List{data: transactions}} = Stripe.Issuing.Transaction.list()
+    assert_stripe_requested(:get, "/v1/issuing/transactions")
+    assert is_list(transactions)
+    assert %Stripe.Issuing.Transaction{} = hd(transactions)
+  end
+end

--- a/test/stripe/issuing/transaction_test.exs
+++ b/test/stripe/issuing/transaction_test.exs
@@ -8,8 +8,10 @@ defmodule Stripe.Issuing.TransactionTest do
 
   test "is updateable" do
     params = %{metadata: %{key: "value"}}
+
     assert {:ok, %Stripe.Issuing.Transaction{}} =
-      Stripe.Issuing.Transaction.update("ipi_123", params)
+             Stripe.Issuing.Transaction.update("ipi_123", params)
+
     assert_stripe_requested(:post, "/v1/issuing/transactions/ipi_123")
   end
 


### PR DESCRIPTION
Adding the Stripe Issuing objects:

- Issuing.Authorization
- Issuing.Card
- Issuing.CardDetails
- Issuing.Cardholder
- Issuing.Dispute
- Issuing.Transaction

https://stripe.com/docs/api/issuing/authorizations
https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.yaml