### PR TITLE
Set minimum elixir version to 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: elixir
 dist: trusty
 elixir:
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
 otp_release:

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Stripe.Mixfile do
         plt_add_apps: [:mix],
         plt_file: {:no_warn, "priv/plts/stripity_stripe.plt"}
       ],
-      elixir: "~> 1.5",
+      elixir: "~> 1.7",
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: [


### PR DESCRIPTION
Elixir 1.7 has been out for nearly a year and 1.8 was released already. I propose the minimum to be set to 1.7

Although StripityStripe self does nor (yet) require specific 1.7+ features, it hinders upgrades of libraries see example https://github.com/code-corps/stripity_stripe/pull/502

If users want to continue using older versions of elixir with this library, it should not be a problem but is not supported.

