### PR TITLE
Allow to set Hackney options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Moreover, if you are using Jason instead of Poison, you can configure the librar
 config :stripity_stripe, json_library: Jason
 ```
 
+### Timeout
+
+To set timeouts, pass opts for the http client. The default one is Hackney.
+
+```ex
+config :stripity_stripe, hackney_opts: [{:connect_timeout, 1000}, {:recv_timeout, 5000}])
+```
+
 ## Note: Object Expansion
 
 Some Stripe API endpoints support returning related objects via the object expansion query parameter. To take advantage of this feature, stripity_stripe accepts

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -135,6 +135,15 @@ defmodule Stripe.API do
     end
   end
 
+  @spec add_options_from_config(list) :: list
+  defp add_options_from_config(opts) do
+    if http_module() == :hackney and is_list(Stripe.Config.resolve(:hackney_opts)) do
+      opts ++ Stripe.Config.resolve(:hackney_opts)
+    else
+      opts
+    end
+  end
+
   @doc """
   A low level utility function to make a direct request to the Stripe API
 
@@ -233,6 +242,7 @@ defmodule Stripe.API do
       []
       |> add_default_options()
       |> add_pool_option()
+      |> add_options_from_config()
 
     http_module().request(method, req_url, req_headers, req_body, req_opts)
     |> handle_response()
@@ -255,6 +265,7 @@ defmodule Stripe.API do
       opts
       |> add_default_options()
       |> add_pool_option()
+      |> add_options_from_config()
 
     http_module().request(method, req_url, req_headers, body, req_opts)
     |> handle_response()

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -39,4 +39,40 @@ defmodule Stripe.APITest do
     {:ok, body} = Stripe.API.oauth_request(:post, "token", %{})
     assert Map.keys(body) |> Enum.member?("Authorization") == false
   end
+
+  test "reads hackney timeout opts from config" do
+    # Return request opts as response body
+    defmodule :hackney do
+      def request(_, _, headers, _, opts) do
+        kv_opts =
+          opts
+          |> Enum.reduce(%{}, fn opt, acc ->
+            case opt do
+              {k, v} ->
+                Map.put(acc, k, v)
+              _ ->
+                Map.put(acc, opt, opt)
+            end
+          end)
+
+        {:ok, 200, headers, Poison.encode!(kv_opts)}
+      end
+    end
+
+    Application.put_env(:stripity_stripe, :http_module, :hackney)
+
+    {:ok, request_opts} = Stripe.API.request(%{}, :get, "/", %{}, [])
+    refute Map.has_key?(request_opts, "connect_timeout")
+    refute Map.has_key?(request_opts, "recv_timeout")
+
+    Application.put_env(:stripity_stripe, :hackney_opts, [{:connect_timeout, 1000}, {:recv_timeout, 5000}])
+
+    {:ok, request_opts} = Stripe.API.oauth_request(:post, "token", %{})
+    assert request_opts["connect_timeout"] == 1000
+    assert request_opts["recv_timeout"] == 5000
+
+    {:ok, request_opts} = Stripe.API.request(%{}, :get, "/", %{}, [])
+    assert request_opts["connect_timeout"] == 1000
+    assert request_opts["recv_timeout"] == 5000
+  end
 end


### PR DESCRIPTION
I've run into problems with timeouts (>5 seconds) coming from our Stripe test account, it has a lot of objects and generally performs slower than live environment.

The only piece of documentation regarding timeouts is here https://hexdocs.pm/stripity_stripe/Stripe.html#module-http-connection-pool But it doesn't change for how long the library waits for the server's response.

This change allows to set that timeout as additional opts for the default Hackney HTTP client. I'm not sure if the config format is right here, maybe you have some other convention that should be followd.