### PR TITLE
Add support for sending invoices.

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -264,4 +264,15 @@ defmodule Stripe.Invoice do
     |> put_method(:post)
     |> make_request()
   end
+
+  @doc """
+  Send an invoice
+  """
+  @spec send(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def send(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}/send")
+    |> put_method(:post)
+    |> make_request()
+  end
 end

--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -266,7 +266,7 @@ defmodule Stripe.Invoice do
   end
 
   @doc """
-  Send an invoice
+  Send an invoice. https://stripe.com/docs/api/invoices/send
   """
   @spec send(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
   def send(id, opts \\ []) do

--- a/test/stripe/core_resources/payment_intent_test.exs
+++ b/test/stripe/core_resources/payment_intent_test.exs
@@ -14,7 +14,7 @@ defmodule Stripe.PaymentIntentTest do
   end
 
   test "is creatable" do
-    params = %{amount: 100, currency: "USD", payment_method_types: ["card"], source: "src_123"}
+    params = %{amount: 100, currency: "USD", payment_method_types: ["card"]}
     assert {:ok, %Stripe.PaymentIntent{}} = Stripe.PaymentIntent.create(params)
     assert_stripe_requested(:post, "/v1/payment_intents")
   end

--- a/test/stripe/subscriptions/invoice_test.exs
+++ b/test/stripe/subscriptions/invoice_test.exs
@@ -101,4 +101,14 @@ defmodule Stripe.InvoiceTest do
       assert_stripe_requested(:post, "/v1/invoices/#{invoice.id}/void")
     end
   end
+
+  describe "send/2" do
+    test "sends an invoice" do
+      {:ok, invoice} = Stripe.Invoice.retrieve("in_123")
+      assert_stripe_requested(:get, "/v1/invoices/#{invoice.id}")
+
+      assert {:ok, %Stripe.Invoice{} = _sent_invoice} = Stripe.Invoice.send(invoice)
+      assert_stripe_requested(:post, "/v1/invoices/#{invoice.id}/send")
+    end
+  end
 end


### PR DESCRIPTION
`Stripe.Invoice.send/2` was missing from the `lib/stripe/subscriptions/invoice.ex`. Added the endpoint and an additional test to the corresponding test file.