### PR TITLE
Warn when unknown objects are processed

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -66,8 +66,12 @@ defmodule Stripe.Converter do
   @spec convert_value(any) :: any
   defp convert_value(%{"object" => object_name} = value) when is_binary(object_name) do
     case Enum.member?(@supported_objects, object_name) do
-      true -> convert_stripe_object(value)
-      false -> convert_map(value)
+      true ->
+        convert_stripe_object(value)
+
+      false ->
+        warn_unknown_object(value)
+        convert_map(value)
     end
   end
 
@@ -110,6 +114,16 @@ defmodule Stripe.Converter do
   defp convert_list(list), do: list |> Enum.map(&convert_value/1)
 
   if Mix.env() == "prod" do
+    defp warn_unknown_object(_), do: :ok
+  else
+    defp warn_unknown_object(%{"object" => object_name} = value) do
+      require Logger
+
+      Logger.warn("Unknown object received: #{object_name}")
+    end
+  end
+
+  if Mix.env() == "prod" do
     defp check_for_extra_keys(_, _), do: :ok
   else
     defp check_for_extra_keys(struct_keys, map) do
@@ -140,7 +154,7 @@ defmodule Stripe.Converter do
 
         details = "#{module_name}: #{inspect(extra_keys)}"
         message = "Extra keys were received but ignored when converting #{details}"
-        Logger.debug(message)
+        Logger.warn(message)
       end
 
       :ok


### PR DESCRIPTION
When the converter sees an unknown object in dev/test env it should issue a warning.
Also changed the logger level when the converter encounters unknown keys in dev/test so it'll output those fields when running the tests.

Fixes https://github.com/code-corps/stripity_stripe/issues/306