### PR TITLE
Support upcoming invoices with subscription only

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -245,7 +245,11 @@ defmodule Stripe.Invoice do
   Retrieve an upcoming invoice.
   """
   @spec upcoming(map, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
-  def upcoming(params = %{customer: _customer}, opts \\ []) do
+  def upcoming(params, opts \\ [])
+  def upcoming(params = %{customer: _customer}, opts), do: get_upcoming(params, opts)
+  def upcoming(params = %{subscription: _subscription}, opts), do: get_upcoming(params, opts)
+
+  defp get_upcoming(params, opts) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/upcoming")
     |> put_method(:get)

--- a/test/stripe/subscriptions/invoice_test.exs
+++ b/test/stripe/subscriptions/invoice_test.exs
@@ -27,6 +27,12 @@ defmodule Stripe.InvoiceTest do
       )
     end
 
+    test "retrieves an upcoming invoice for a subscription" do
+      params = %{subscription: "sub_123"}
+      assert {:ok, %Stripe.Invoice{}} = Stripe.Invoice.upcoming(params)
+      assert_stripe_requested(:get, "/v1/invoices/upcoming", query: %{subscription: "sub_123"})
+    end
+
     test "retrieves an upcoming invoice for a customer with items" do
       items = [%{plan: "gold", quantity: 2}]
       params = %{customer: "cus_123", subscription_items: items}


### PR DESCRIPTION
According to the Stripe [upcoming invoice API](https://stripe.com/docs/api/invoices/upcoming), one of `customer` or `subscription` must be set but `stripity_stripe` currently only checks if the `customer` key is included in the params map.

This PR fixes it and also allows params that have `subscription` but not `customer`.