### PR TITLE
Allow Customer.create/2 to take Source id in typespecs.

### DIFF
--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -90,7 +90,7 @@ defmodule Stripe.Customer do
                  optional(:invoice_settings) => Stripe.Invoice.invoice_settings(),
                  optional(:metadata) => Stripe.Types.metadata(),
                  optional(:shipping) => Stripe.Types.shipping(),
-                 optional(:source) => Stripe.Source.t(),
+                 optional(:source) => Stripe.id() | Stripe.Source.t(),
                  optional(:tax_info) => Stripe.Types.tax_info()
                }
                | %{}


### PR DESCRIPTION
We're already coercing the source to an id via the `cast_to_id` call,
this just makes the typespec match the implementation.

Closes #478