### PR TITLE
Fixed compile warning in converter.ex

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -117,7 +117,7 @@ defmodule Stripe.Converter do
   if Mix.env() == "prod" do
     defp warn_unknown_object(_), do: :ok
   else
-    defp warn_unknown_object(%{"object" => object_name} = value) do
+    defp warn_unknown_object(%{"object" => object_name}) do
       require Logger
 
       Logger.warn("Unknown object received: #{object_name}")


### PR DESCRIPTION
Previously:
```
Compiling 67 files (.ex)
[Warn  - 11:20:41 AM] warning: variable "value" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/stripe/converter.ex:120

Generated stripity_stripe app
```

After
```
Compiling 67 files (.ex)
Generated stripity_stripe app
```
