### PR TITLE
Add payment intent to session

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -66,12 +66,14 @@ defmodule Stripe.Session do
   @type t :: %__MODULE__{
           :id => Stripe.id(),
           :object => String.t(),
+          :payment_intent => Stripe.id() | Stripe.PaymentIntent.t(),
           :livemode => boolean()
         }
 
   defstruct [
     :id,
     :object,
+    :payment_intent,
     :livemode
   ]
 


### PR DESCRIPTION
This adds the payment_intent to a session to match the API definition.