### PR TITLE
Make stripe version configurable

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -23,6 +23,8 @@ defmodule Stripe do
 
     * `:api_key` - The Stripe API key to use for the request. See
       [https://stripe.com/docs/api/authentication](https://stripe.com/docs/api/authentication)
+    * `:api_version` - The version of the api that is being used, defaults to the
+      version the library is written for. See [https://stripe.com/docs/api/versioning](https://stripe.com/docs/api/versioning)
     * `:connect_account` - The ID of a Stripe Connect account for which the
       request should be made, passed through as the "Stripe-Account" header. The
       preferred authentication method for Stripe Connect. See

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -146,6 +146,17 @@ defmodule Stripe.API do
   @doc """
   A low level utility function to make a direct request to the Stripe API
 
+  ## Setting the api key
+
+      request(%{}, :get, "/customers", %{}, api_key: "bogus key")
+
+  ## Setting api version
+
+  The api version defaults to #{@api_version} but a custom version can be passed
+  in as follows:
+
+      request(%{}, :get, "/customers", %{}, api_version: "2018-11-04")
+
   ## Connect Accounts
 
   If you'd like to make a request on behalf of another Stripe account

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -1,7 +1,6 @@
 defmodule Stripe.APITest do
-  use ExUnit.Case
-
   import Mox
+  use Stripe.StripeCase
 
   test "works with 301 responses without issue" do
     {:error, %Stripe.Error{extra: %{http_status: 301}}} =
@@ -15,6 +14,21 @@ defmodule Stripe.APITest do
     |> expect(:oauth_request, fn method, _endpoint, _body -> method end)
 
     assert Stripe.APIMock.oauth_request(:post, "www", %{body: "body"}) == :post
+  end
+
+  test "gets default api version" do
+    Stripe.API.request(%{}, :get, "products", %{}, [])
+    assert_stripe_requested(:get, "/v1/products", headers: {"Stripe-Version", "2019-05-16"})
+  end
+
+  test "can set custom api version" do
+    Stripe.API.request(%{}, :get, "products", %{},
+      api_version: "2019-05-16; checkout_sessions_beta=v1"
+    )
+
+    assert_stripe_requested(:get, "/v1/products",
+      headers: {"Stripe-Version", "2019-05-16; checkout_sessions_beta=v1"}
+    )
   end
 
   test "oauth_request sets authorization header for deauthorize request" do


### PR DESCRIPTION
Fixes https://github.com/code-corps/stripity_stripe/issues/521

The beta flag is no longer needed, but for those who need the api version header has been made configurable by passing it in the opts