### PR TITLE
Add balance to customer entity

### DIFF
--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -20,6 +20,7 @@ defmodule Stripe.Customer do
           object: String.t(),
           account_balance: integer,
           address: Stripe.Types.address() | nil,
+          balance: integer,
           created: Stripe.timestamp(),
           currency: String.t() | nil,
           default_source: Stripe.id() | Stripe.Source.t() | nil,
@@ -49,6 +50,7 @@ defmodule Stripe.Customer do
     :object,
     :account_balance,
     :address,
+    :balance,
     :created,
     :currency,
     :default_source,
@@ -82,6 +84,7 @@ defmodule Stripe.Customer do
         when params:
                %{
                  optional(:account_balance) => integer,
+                 optional(:balance) => integer,
                  optional(:coupon) => Stripe.id() | Stripe.Coupon.t(),
                  optional(:default_source) => Stripe.id() | Stripe.Source.t(),
                  optional(:description) => String.t(),
@@ -121,6 +124,7 @@ defmodule Stripe.Customer do
         when params:
                %{
                  optional(:account_balance) => integer,
+                 optional(:balance) => integer,
                  optional(:coupon) => Stripe.id() | Stripe.Coupon.t(),
                  optional(:default_source) => Stripe.id() | Stripe.Source.t(),
                  optional(:description) => String.t(),


### PR DESCRIPTION
`account_balance` was renamed to `balance` see
https://stripe.com/docs/api/customers/object#customer_object-account_balance and https://github.com/code-corps/stripity_stripe/issues/517