### PR TITLE
Include `person` in `@supported_objects`

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -45,6 +45,7 @@ defmodule Stripe.Converter do
     payment_intent
     payment_method
     payout
+    person
     plan
     product
     recipient


### PR DESCRIPTION
I noticed that the person endpoint has only recently been added, hoping that it's exclusion in this list is just an oversight 🙂. Empty fields are causing me issues in my integration