### PR TITLE
Fix production env check for additional Stripe response converter logging

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -117,7 +117,7 @@ defmodule Stripe.Converter do
   @spec convert_list(list) :: list
   defp convert_list(list), do: list |> Enum.map(&convert_value/1)
 
-  if Mix.env() == "prod" do
+  if Mix.env() == :prod do
     defp warn_unknown_object(_), do: :ok
   else
     defp warn_unknown_object(%{"object" => object_name}) do
@@ -127,7 +127,7 @@ defmodule Stripe.Converter do
     end
   end
 
-  if Mix.env() == "prod" do
+  if Mix.env() == :prod do
     defp check_for_extra_keys(_, _), do: :ok
   else
     defp check_for_extra_keys(struct_keys, map) do


### PR DESCRIPTION
[`Mix.env/0`](https://hexdocs.pm/mix/Mix.html#env/0) returns an atom, not a string. The conditional check for production environment to disable additional logging needs to compare `Mix.env()` with `:prod` (atom), not `"prod"` (string). 

```
$ MIX_ENV=prod iex

iex(1)> Application.ensure_all_started(:mix)
{:ok, [:mix]}

iex(2)> Mix.env()         
:prod
```

This issue was discovered by seeing the "Extra keys were received but ignored ..." log message in production logs.