### PR TITLE
add account links

### DIFF
--- a/lib/stripe/connect/account_link.ex
+++ b/lib/stripe/connect/account_link.ex
@@ -29,7 +29,7 @@ defmodule Stripe.AccountLink do
   @plural_endpoint "account_links"
 
   @doc """
-  Create an account.
+  Create an account link.
   """
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params: %{

--- a/lib/stripe/connect/account_link.ex
+++ b/lib/stripe/connect/account_link.ex
@@ -1,0 +1,50 @@
+defmodule Stripe.AccountLink do
+  @moduledoc """
+  Work with Stripe Connect account link objects.
+
+  You can:
+
+  - Create an account link
+
+  Stripe API reference: https://stripe.com/docs/api/account_links
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          object: String.t(),
+          created: Stripe.timestamp(),
+          expires_at: Stripe.timestamp(),
+          url: String.t()
+        }
+
+  defstruct [
+    :object,
+    :created,
+    :expires_at,
+    :url
+  ]
+
+  @plural_endpoint "account_links"
+
+  @doc """
+  Create an account.
+  """
+  @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+               :account => Stripe.Account.t() | Stripe.id(),
+               :failure_url => String.t(),
+               :success_url => String.t(),
+               :type => String.t(),
+               optional(:collect) => String.t()
+             }
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> cast_to_id([:account])
+    |> make_request()
+  end
+end

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -12,6 +12,7 @@ defmodule Stripe.Converter do
 
   @supported_objects ~w(
     account
+    account_link
     application_fee
     fee_refund
     balance

--- a/test/stripe/connect/account_link_test.exs
+++ b/test/stripe/connect/account_link_test.exs
@@ -1,0 +1,15 @@
+defmodule Stripe.AccountLinkTest do
+  use Stripe.StripeCase, async: true
+
+  test "is creatable" do
+    params = %{
+      account: "acct_123",
+      failure_url: "https://stripe.com",
+      success_url: "https://stripe.com",
+      type: "custom_account_verification"
+    }
+
+    assert {:ok, %Stripe.AccountLink{}} = Stripe.AccountLink.create(params)
+    assert_stripe_requested(:post, "/v1/account_links")
+  end
+end


### PR DESCRIPTION
Stripe added a new concept called AccountLinks for Custom Connect, which allows you to send users to a Stripe-hosted form to go through onboarding. This PR adds the necessary resources to make it available.

See documentation here: https://stripe.com/docs/api/account_links

As always, thanks for maintaining and I welcome any feedback 😃