### PR TITLE
Update billing attr to collection_method in Stripe.Invoice.create

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -182,7 +182,7 @@ defmodule Stripe.Invoice do
                %{
                  optional(:application_fee_amount) => integer,
                  optional(:auto_advance) => boolean,
-                 optional(:billing) => String.t(),
+                 optional(:collection_method) => String.t(),
                  :customer => Stripe.id() | Stripe.Customer.t(),
                  optional(:custom_fields) => custom_fields,
                  optional(:days_until_due) => integer,


### PR DESCRIPTION
https://stripe.com/docs/api/invoices/object#invoice_object-collection_method

> The `billing` attribute on invoices, subscriptions, and subscription schedules is renamed to `collection_method`.