### PR TITLE
Updates for Stripe API 2019-12-03

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -16,7 +16,7 @@ defmodule Stripe.API do
   @typep http_failure :: {:error, term}
 
   @pool_name __MODULE__
-  @api_version "2019-10-17"
+  @api_version "2019-12-03"
 
   @idempotency_key_header "Idempotency-Key"
 

--- a/lib/stripe/connect/person.ex
+++ b/lib/stripe/connect/person.ex
@@ -22,7 +22,7 @@ defmodule Stripe.Person do
   end
 
   @type relationship :: %{
-          account_opener: boolean() | nil,
+          representative: boolean() | nil,
           director: boolean() | nil,
           owner: boolean() | nil,
           percent_ownership: float() | nil,

--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -82,15 +82,18 @@ defmodule Stripe.Customer do
                  optional(:address) => Stripe.Types.address(),
                  optional(:balance) => integer,
                  optional(:coupon) => Stripe.id() | Stripe.Coupon.t(),
-                 optional(:default_source) => Stripe.id() | Stripe.Source.t(),
                  optional(:description) => String.t(),
                  optional(:email) => String.t(),
                  optional(:invoice_prefix) => String.t(),
                  optional(:invoice_settings) => Stripe.Invoice.invoice_settings(),
                  optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:name) => String.t(),
                  optional(:payment_method) => String.t(),
+                 optional(:phone) => String.t(),
+                 optional(:preferred_locales) => list(String.t()),
                  optional(:shipping) => Stripe.Types.shipping(),
                  optional(:source) => Stripe.id() | Stripe.Source.t(),
+                 optional(:tax_excempt) => String.t(),
                  optional(:tax_id_data) => Stripe.TaxID.tax_id_data()
                }
                | %{}
@@ -129,9 +132,12 @@ defmodule Stripe.Customer do
                  optional(:invoice_prefix) => String.t(),
                  optional(:invoice_settings) => Stripe.Invoice.invoice_settings(),
                  optional(:metadata) => Stripe.Types.metadata(),
-                 optional(:tax_id_data) => Stripe.TaxID.tax_id_data(),
+                 optional(:name) => String.t(),
+                 optional(:phone) => String.t(),
+                 optional(:preferred_locales) => list(String.t()),
                  optional(:shipping) => Stripe.Types.shipping(),
-                 optional(:source) => Stripe.Source.t()
+                 optional(:source) => Stripe.Source.t(),
+                 optional(:tax_excempt) => String.t()
                }
                | %{}
   def update(id, params, opts \\ []) do

--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -40,9 +40,7 @@ defmodule Stripe.Customer do
           sources: Stripe.List.t(Stripe.Source.t()),
           subscriptions: Stripe.List.t(Stripe.Subscription.t()),
           tax_exempt: String.t() | nil,
-          tax_ids: Stripe.List.t(Stripe.TaxID.t()),
-          tax_info: Stripe.Types.tax_info() | nil,
-          tax_info_verification: Stripe.Types.tax_info_verification() | nil
+          tax_ids: Stripe.List.t(Stripe.TaxID.t())
         }
 
   defstruct [
@@ -70,9 +68,7 @@ defmodule Stripe.Customer do
     :sources,
     :subscriptions,
     :tax_exempt,
-    :tax_ids,
-    :tax_info,
-    :tax_info_verification
+    :tax_ids
   ]
 
   @plural_endpoint "customers"
@@ -93,7 +89,7 @@ defmodule Stripe.Customer do
                  optional(:metadata) => Stripe.Types.metadata(),
                  optional(:shipping) => Stripe.Types.shipping(),
                  optional(:source) => Stripe.id() | Stripe.Source.t(),
-                 optional(:tax_info) => Stripe.Types.tax_info(),
+                 optional(:tax_id_data) => Stripe.TaxID.tax_id_data(),
                  optional(:payment_method) => String.t()
                }
                | %{}
@@ -133,7 +129,7 @@ defmodule Stripe.Customer do
                  optional(:metadata) => Stripe.Types.metadata(),
                  optional(:shipping) => Stripe.Types.shipping(),
                  optional(:source) => Stripe.Source.t(),
-                 optional(:tax_info) => Stripe.Types.tax_info()
+                 optional(:tax_id_data) => Stripe.TaxID.tax_id_data()
                }
                | %{}
   def update(id, params, opts \\ []) do

--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -79,6 +79,7 @@ defmodule Stripe.Customer do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 optional(:address) => Stripe.Types.address(),
                  optional(:balance) => integer,
                  optional(:coupon) => Stripe.id() | Stripe.Coupon.t(),
                  optional(:default_source) => Stripe.id() | Stripe.Source.t(),
@@ -87,10 +88,10 @@ defmodule Stripe.Customer do
                  optional(:invoice_prefix) => String.t(),
                  optional(:invoice_settings) => Stripe.Invoice.invoice_settings(),
                  optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:payment_method) => String.t(),
                  optional(:shipping) => Stripe.Types.shipping(),
                  optional(:source) => Stripe.id() | Stripe.Source.t(),
-                 optional(:tax_id_data) => Stripe.TaxID.tax_id_data(),
-                 optional(:payment_method) => String.t()
+                 optional(:tax_id_data) => Stripe.TaxID.tax_id_data()
                }
                | %{}
   def create(params, opts \\ []) do
@@ -119,6 +120,7 @@ defmodule Stripe.Customer do
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 optional(:address) => Stripe.Types.address(),
                  optional(:balance) => integer,
                  optional(:coupon) => Stripe.id() | Stripe.Coupon.t(),
                  optional(:default_source) => Stripe.id() | Stripe.Source.t(),
@@ -127,9 +129,9 @@ defmodule Stripe.Customer do
                  optional(:invoice_prefix) => String.t(),
                  optional(:invoice_settings) => Stripe.Invoice.invoice_settings(),
                  optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:tax_id_data) => Stripe.TaxID.tax_id_data(),
                  optional(:shipping) => Stripe.Types.shipping(),
-                 optional(:source) => Stripe.Source.t(),
-                 optional(:tax_id_data) => Stripe.TaxID.tax_id_data()
+                 optional(:source) => Stripe.Source.t()
                }
                | %{}
   def update(id, params, opts \\ []) do

--- a/lib/stripe/core_resources/tax_id.ex
+++ b/lib/stripe/core_resources/tax_id.ex
@@ -27,6 +27,11 @@ defmodule Stripe.TaxID do
           verified_address: String.t() | nil
         }
 
+  @type tax_id_data :: %{
+          type: String.t(),
+          value: String.t()
+        }
+
   defstruct [
     :id,
     :object,

--- a/lib/stripe/subscriptions/subscription_schedule.ex
+++ b/lib/stripe/subscriptions/subscription_schedule.ex
@@ -21,20 +21,25 @@ defmodule Stripe.SubscriptionSchedule do
           plans: list(plans)
         }
 
+  @type default_settings :: %{
+          billing_thresholds: Stripe.Types.collection_method_thresholds() | nil,
+          collection_method: String.t(),
+          default_payment_method: Stripe.id() | Stripe.PaymentMethod.t(),
+          invoice_settings: %{
+            days_until_due: integer
+          }
+        }
+
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
-          billing_thresholds: Stripe.Types.collection_method_thresholds() | nil,
           created: Stripe.timestamp(),
           canceled_at: Stripe.timestamp() | nil,
           released_at: Stripe.timestamp() | nil,
-          collection_method: String.t(),
           completed_at: Stripe.timestamp() | nil,
           livemode: boolean,
           metadata: Stripe.Types.metadata(),
-          invoice_settings: %{
-            days_until_due: integer
-          },
+          default_settings: default_settings,
           current_phase: %{
             start_date: Stripe.timestamp(),
             end_date: Stripe.timestamp()
@@ -45,27 +50,23 @@ defmodule Stripe.SubscriptionSchedule do
           subscription: Stripe.id() | Stripe.Subscription.t(),
           customer: Stripe.id() | Stripe.Customer.t(),
           released_subscription: Stripe.id() | Stripe.Subscription.t() | nil,
-          default_payment_method: Stripe.id() | Stripe.PaymentMethod.t(),
           phases: list(phases)
         }
 
   defstruct [
     :id,
     :object,
-    :billing_thresholds,
     :created,
     :canceled_at,
-    :collection_method,
     :completed_at,
     :current_phase,
     :customer,
-    :default_payment_method,
     :phases,
     :released_at,
     :released_subscription,
     :status,
     :subscription,
-    :invoice_settings,
+    :default_settings,
     :livemode,
     :metadata,
     :end_behavior,
@@ -86,12 +87,14 @@ defmodule Stripe.SubscriptionSchedule do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params: %{
                optional(:customer) => Stripe.id(),
-               optional(:collection_method) => String.t(),
                optional(:from_subscription) => Stripe.id(),
-               optional(:invoice_settings) => %{
-                 optional(:days_until_due) => non_neg_integer
+               optional(:default_settings) => %{
+                 optional(:collection_method) => String.t(),
+                 optional(:default_payment_method) => Stripe.id(),
+                 optional(:invoice_settings) => %{
+                   optional(:days_until_due) => non_neg_integer
+                 }
                },
-               optional(:default_payment_method) => Stripe.id(),
                optional(:phases) => [
                  %{
                    :plans => [
@@ -138,11 +141,13 @@ defmodule Stripe.SubscriptionSchedule do
   """
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params: %{
-               optional(:collection_method) => String.t(),
-               optional(:invoice_settings) => %{
-                 optional(:days_until_due) => non_neg_integer
+               optional(:default_settings) => %{
+                 optional(:collection_method) => String.t(),
+                 optional(:default_payment_method) => Stripe.id(),
+                 optional(:invoice_settings) => %{
+                   optional(:days_until_due) => non_neg_integer
+                 }
                },
-               optional(:default_payment_method) => Stripe.id(),
                optional(:phases) => [
                  %{
                    :plans => [

--- a/lib/stripe/types.ex
+++ b/lib/stripe/types.ex
@@ -56,16 +56,6 @@ defmodule Stripe.Types do
           reset_billing_cycle_anchor: boolean | nil
         }
 
-  @type tax_info :: %{
-          type: String.t(),
-          tax_id: String.t() | nil
-        }
-
-  @type tax_info_verification :: %{
-          status: String.t() | nil,
-          verified_name: String.t() | nil
-        }
-
   @type transfer_schedule :: %{
           delay_days: non_neg_integer,
           interval: String.t(),

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -85,7 +85,7 @@ defmodule Stripe.APITest do
 
   test "gets default api version" do
     Stripe.API.request(%{}, :get, "products", %{}, [])
-    assert_stripe_requested(:get, "/v1/products", headers: {"Stripe-Version", "2019-10-17"})
+    assert_stripe_requested(:get, "/v1/products", headers: {"Stripe-Version", "2019-12-03"})
   end
 
   test "can set custom api version" do

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -33,8 +33,7 @@ defmodule Stripe.ConverterTest do
             has_more: false,
             total_count: 0,
             url: "/v1/customers/cus_9ryX7lUQ4Dcpf7/subscriptions"
-          },
-          tax_info: nil
+          }
         },
         previous_attributes: %{
           description: "testcustomer",


### PR DESCRIPTION
Includes the data model changes required to work with Stripe API 2019-12-03.

I wasn't sure what to do with version numbers in mix.exs and the README.md. 

Let me know if you'd like me to do anything differently in this PR and/or in this codebase in general.

https://stripe.com/docs/upgrades#2019-12-03