### PR TITLE
Remove duplicate payment_method_types

### DIFF
--- a/lib/stripe/core_resources/payment_intent.ex
+++ b/lib/stripe/core_resources/payment_intent.ex
@@ -131,7 +131,6 @@ defmodule Stripe.PaymentIntent do
                %{
                  :amount => pos_integer,
                  :currency => String.t(),
-                 :payment_method_types => [String.t()],
                  optional(:application_fee_amount) => non_neg_integer,
                  optional(:capture_method) => String.t(),
                  optional(:confirm) => boolean,


### PR DESCRIPTION
payment_method_types is specified twice in the typespec, once required and once optional - the correct one is optional (per https://stripe.com/docs/api/payment_intents/create), so removed the required one.