### PR TITLE
Add reporting category to balance transactions

### DIFF
--- a/lib/stripe/core_resources/balance_transaction.ex
+++ b/lib/stripe/core_resources/balance_transaction.ex
@@ -22,6 +22,7 @@ defmodule Stripe.BalanceTransaction do
           fee: integer,
           fee_details: list(Stripe.Types.fee()) | [],
           net: integer,
+          reporting_category: String.t(),
           source: Stripe.id() | Stripe.Source.t() | nil,
           status: String.t(),
           type: String.t()
@@ -39,6 +40,7 @@ defmodule Stripe.BalanceTransaction do
     :fee,
     :fee_details,
     :net,
+    :reporting_category,
     :source,
     :status,
     :type


### PR DESCRIPTION
Stripe recently added a new `reporting_category` field to balance transactions that better groups transactions into accounting-style groups. This adds that field to the fields we're pulling off of balance transactions in the Converter.

![image](https://user-images.githubusercontent.com/3421625/74782464-bc6fc100-5260-11ea-95d7-3ffe9b078894.png)
