### PR TITLE
Add a card_error_code returned by a failed-verification bank account

### DIFF
--- a/lib/stripe/error.ex
+++ b/lib/stripe/error.ex
@@ -88,6 +88,7 @@ defmodule Stripe.Error do
           | :card_declined
           | :missing
           | :processing_error
+          | :bank_account_verification_failed
 
   @type t :: %__MODULE__{
           source: error_source,


### PR DESCRIPTION
As seen in this response to a call to Stripe.BankAccount.verify:

```
%Stripe.Error{
  code: :invalid_request_error,
  extra: %{
    card_code: :bank_account_verification_failed,
    http_status: 402,
    raw_error: %{
      "code" => "bank_account_verification_failed",
      "doc_url" => "https://stripe.com/docs/error-codes/bank-account-verification-failed",
      "message" => "The amounts provided do not match the amounts that were sent to the bank account.",
      "type" => "invalid_request_error"
    }
  },
  message: "The amounts provided do not match the amounts that were sent to the bank account.",
  request_id: nil,
  source: :stripe,
  user_message: nil
}
```