### PR TITLE
Add description to Stripe.Transfer.create/2 spec

### DIFF
--- a/lib/stripe/connect/transfer.ex
+++ b/lib/stripe/connect/transfer.ex
@@ -60,7 +60,8 @@ defmodule Stripe.Transfer do
                :destination => Stripe.id() | Stripe.Account.t(),
                optional(:metadata) => Stripe.Types.metadata(),
                optional(:source_transaction) => Stripe.id() | Stripe.Charge.t(),
-               optional(:transfer_group) => String.t()
+               optional(:transfer_group) => String.t(),
+               optional(:description) => String.t()
              }
   def create(%{amount: _, currency: _, destination: _} = params, opts \\ []) do
     new_request(opts)


### PR DESCRIPTION
The description field was missing from the spec. See https://stripe.com/docs/api/transfers/create?lang=curl