### PR TITLE
Corrected mis-placed parens in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ config :stripity_stripe, json_library: Poison
 To set timeouts, pass opts for the http client. The default one is Hackney.
 
 ```ex
-config :stripity_stripe, hackney_opts: [{:connect_timeout, 1000}, {:recv_timeout, 5000}])
+config :stripity_stripe, hackney_opts: [{:connect_timeout, 1000}, {:recv_timeout, 5000}]
 ```
 
 ### Request Retries


### PR DESCRIPTION
I did a copy/paste for the hackney opts and there was a parens hanging on there, just chilling and relaxing. Just waiting to mess up people's flow.