### PR TITLE
add Stripe.Converter.structs() to enumerate all generated structs

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -68,6 +68,29 @@ defmodule Stripe.Converter do
 
   @no_convert_maps ~w(metadata supported_bank_account_currencies)
 
+  @doc """
+  Returns a list of structs to be used for providing JSON-encoders.
+
+  ## Examples
+
+  Say you are using Jason to encode your JSON, you can provide the following protocol,
+  to directly encode all structs of this library into JSON.
+
+  ```
+  for struct <- Stripe.Converter.structs() do
+    defimpl Jason.Encoder, for: struct do
+      def encode(value, opts) do
+        Jason.Encode.map(Map.delete(value, :__struct__), opts)
+      end
+    end
+  end
+  ```
+  """
+  def structs() do
+    (@supported_objects -- @no_convert_maps)
+    |> Enum.map(&Stripe.Util.object_name_to_module/1)
+  end
+
   @spec convert_value(any) :: any
   defp convert_value(%{"object" => object_name} = value) when is_binary(object_name) do
     case Enum.member?(@supported_objects, object_name) do


### PR DESCRIPTION
This change helps users of different JSON libraries to directly encode your structs without having to remap them to Maps.

I am consuming the Stripe webhooks API, and there I am are storing all valid incoming webhooks in an events database.
The valid events must be converted back to JSON. For that I would like to call Elixir-protocols for help, to do the nasty work for me.

The documentation of the new function `Stripe.Converter.structs/0` reads:

<hr>

Returns a list of structs to be used for providing JSON-encoders.

## Examples

Say you are using Jason to encode your JSON, you can provide the following protocol,
to directly encode all structs of this library into JSON.

```
for struct <- Stripe.Converter.structs() do
  defimpl Jason.Encoder, for: struct do
    def encode(value, opts) do
      Jason.Encode.map(Map.delete(value, :__struct__), opts)
    end
  end
end
```