### PR TITLE
Update invoice.ex

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -88,9 +88,9 @@ defmodule Stripe.Invoice do
           })
 
   @type invoice_settings :: %{
-          optional(:default_payment_method) => String.t() | nil,
-          optional(:custom_fields) => custom_fields | nil,
-          optional(:footer) => String.t() | nil
+          optional(:default_payment_method) => String.t(),
+          optional(:custom_fields) => custom_fields,
+          optional(:footer) => String.t()
         }
 
   @type status_transitions ::

--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -88,9 +88,9 @@ defmodule Stripe.Invoice do
           })
 
   @type invoice_settings :: %{
-          default_payment_method: String.t() | nil,
-          custom_fields: custom_fields | nil,
-          footer: String.t() | nil
+          optional(:default_payment_method) => String.t() | nil,
+          optional(:custom_fields) => custom_fields | nil,
+          optional(:footer) => String.t() | nil
         }
 
   @type status_transitions ::


### PR DESCRIPTION
Not all the invoice_settings fields are required when calling 
`Stripe.Customer.update`

https://stripe.com/docs/api/customers/update

<img width="609" alt="image" src="https://user-images.githubusercontent.com/2143646/79139919-6da15c00-7db7-11ea-8895-a9e393d4a4d1.png">
