### PR TITLE
changed params for subscription to accept default payment method

### DIFF
--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -164,6 +164,7 @@ defmodule Stripe.Subscription do
                optional(:items) => [
                  %{
                    :plan => Stripe.id() | Stripe.Plan.t(),
+                   optional(:id) => Stripe.id() | binary(),
                    optional(:billing_methods) => map,
                    optional(:metadata) => map,
                    optional(:quantity) => non_neg_integer,

--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -124,7 +124,7 @@ defmodule Stripe.Subscription do
                optional(:trial_from_plan) => boolean,
                optional(:trial_period_days) => non_neg_integer
              }
-  def create(%{customer: _, items: _} = params, opts \\ []) do
+  def create(params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint)
     |> put_params(params)


### PR DESCRIPTION
Made a minor change to the api that allows you to pass a default payment method directly into the parameters of Stripe.Subscription.create. 