### PR TITLE
Make subscription_data keys for Checkout optional

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -47,8 +47,12 @@ defmodule Stripe.Session do
 
   @type subscription_data :: %{
           :items => list(item),
+          optional(:application_fee_percent) => float(),
+          optional(:coupon) => String.t(),
+          optional(:default_tax_rates) => list(String.t()),
           optional(:metadata) => Stripe.Types.metadata(),
           optional(:trial_end) => integer(),
+          optional(:trial_from_plan) => boolean(),
           optional(:trial_period_days) => integer()
         }
 

--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -47,9 +47,9 @@ defmodule Stripe.Session do
 
   @type subscription_data :: %{
           :items => list(item),
-          :metadata => Stripe.Types.metadata(),
-          :trial_end => integer(),
-          :trial_period_days => integer()
+          optional(:metadata) => Stripe.Types.metadata(),
+          optional(:trial_end) => integer(),
+          optional(:trial_period_days) => integer()
         }
 
   @type create_params :: %{


### PR DESCRIPTION
It is possible to use the Stripe API without providing these keys. They
are optional so we flag them as such to keep dialyzer happy.

The Stripe docs indicate that only 'items' is required:

  https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-subscription_data

Closes #568 