### PR TITLE
Add optional `customer` to session create params

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -61,6 +61,7 @@ defmodule Stripe.Session do
           :payment_method_types => list(String.t()),
           :success_url => String.t(),
           optional(:client_reference_id) => String.t(),
+          optional(:customer) => String.t(),
           optional(:customer_email) => String.t(),
           optional(:line_items) => list(line_item),
           optional(:locale) => String.t(),


### PR DESCRIPTION
Adds an [optional `customer` attribute](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-customer) to the checkout session's `create_params` type.

Fixes #600. 