### PR TITLE
Add support for Price core resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 sudo: false
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.70.0
+    - STRIPE_MOCK_VERSION=0.90.0
     - MIX_ENV=test STRIPE_SECRET_KEY=non_empty_secret_key_string
 cache:
   directories:

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -48,6 +48,7 @@ defmodule Stripe.Converter do
     payout
     person
     plan
+    price
     product
     recipient
     refund

--- a/lib/stripe/core_resources/event.ex
+++ b/lib/stripe/core_resources/event.ex
@@ -32,6 +32,7 @@ defmodule Stripe.Event do
           | Stripe.Payout.t()
           | Stripe.Plan.t()
           | Stripe.Relay.Product.t()
+          | Stripe.Price.t()
           | Stripe.Product.t()
           | Stripe.Recipient.t()
           | Stripe.Review.t()

--- a/lib/stripe/subscriptions/invoiceitem.ex
+++ b/lib/stripe/subscriptions/invoiceitem.ex
@@ -28,6 +28,7 @@ defmodule Stripe.Invoiceitem do
             end: Stripe.timestamp()
           },
           plan: Stripe.Plan.t() | nil,
+          price: Stripe.Price.t() | nil,
           proration: boolean,
           quantity: integer,
           subscription: Stripe.id() | Stripe.Subscription.t() | nil,
@@ -51,6 +52,7 @@ defmodule Stripe.Invoiceitem do
     :metadata,
     :period,
     :plan,
+    :price,
     :proration,
     :quantity,
     :subscription,
@@ -75,6 +77,7 @@ defmodule Stripe.Invoiceitem do
                  optional(:discountable) => boolean,
                  optional(:invoice) => Stripe.id() | Stripe.Invoice.t(),
                  optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:price) => Stripe.id() | Stripe.Price.t(),
                  optional(:quantity) => integer,
                  optional(:subscription) => Stripe.id() | Stripe.Subscription.t(),
                  optional(:tax_rates) => list(String.t()),
@@ -87,7 +90,7 @@ defmodule Stripe.Invoiceitem do
     |> put_endpoint(@plural_endpoint)
     |> put_params(params)
     |> put_method(:post)
-    |> cast_to_id([:subscription])
+    |> cast_to_id([:price, :subscription])
     |> make_request()
   end
 
@@ -114,6 +117,7 @@ defmodule Stripe.Invoiceitem do
                  optional(:description) => String.t(),
                  optional(:discountable) => boolean,
                  optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:price) => Stripe.id() | Stripe.Price.t(),
                  optional(:quantity) => integer,
                  optional(:tax_rates) => list(String.t()),
                  optional(:unit_amount) => integer,
@@ -125,6 +129,7 @@ defmodule Stripe.Invoiceitem do
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
     |> put_method(:post)
     |> put_params(params)
+    |> cast_to_id([:price])
     |> make_request()
   end
 

--- a/lib/stripe/subscriptions/price.ex
+++ b/lib/stripe/subscriptions/price.ex
@@ -1,0 +1,217 @@
+defmodule Stripe.Price do
+  @moduledoc """
+  Work with Stripe price objects.
+
+  The Prices API adds more flexibility to how you charge customers.
+
+  It also replaces the Plans API, so Stripe recommends migrating your existing
+  integration to work with prices.
+
+  To migrate, you need to identify how you use plans, products, and payment
+  flows and then update these parts of your integration to use the Prices API.
+
+  Migrating to Prices guide: https://stripe.com/docs/billing/migration/migrating-prices
+
+  You can:
+
+  - Create a price
+  - Retrieve a price
+  - Update a price
+  - List all prices
+
+  Stripe API reference: https://stripe.com/docs/api/prices
+
+  Example:
+
+  ```
+  {
+    "id": "plan_HJ8MK9HTYgniMM",
+    "object": "price",
+    "active": true,
+    "billing_scheme": "per_unit",
+    "created": 1589897226,
+    "currency": "usd",
+    "livemode": false,
+    "lookup_key": null,
+    "metadata": {},
+    "nickname": null,
+    "product": "prod_HJ8MOtuM1vD2jd",
+    "recurring": {
+      "aggregate_usage": null,
+      "interval": "month",
+      "interval_count": 1,
+      "trial_period_days": null,
+      "usage_type": "licensed"
+    },
+    "tiers": null,
+    "tiers_mode": null,
+    "transform_quantity": null,
+    "type": "recurring",
+    "unit_amount": 999,
+    "unit_amount_decimal": "999"
+  }
+  ```
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type recurring :: %{
+          aggregate_usage: String.t(),
+          interval: String.t(),
+          interval_count: pos_integer,
+          trial_period_days: pos_integer,
+          usage_type: String.t()
+        }
+
+  @type price_tier :: %{
+          flat_amount: integer,
+          flat_amount_decimal: String.t(),
+          unit_amount: integer,
+          unit_amount_decimal: String.t(),
+          up_to: integer
+        }
+
+  @type transform_quantity :: %{
+          divide_by: pos_integer,
+          round: String.t()
+        }
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          active: boolean,
+          billing_scheme: String.t(),
+          created: Stripe.timestamp(),
+          currency: String.t(),
+          livemode: boolean,
+          lookup_key: String.t(),
+          metadata: Stripe.Types.metadata(),
+          nickname: String.t(),
+          product: Stripe.id() | Stripe.Product.t(),
+          recurring: recurring(),
+          tiers: [price_tier()],
+          tiers_mode: String.t(),
+          transform_quantity: transform_quantity(),
+          type: String.t(),
+          unit_amount: pos_integer,
+          amount_decimal: String.t()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :active,
+    :billing_scheme,
+    :created,
+    :currency,
+    :livemode,
+    :lookup_key,
+    :metadata,
+    :nickname,
+    :product,
+    :recurring,
+    :tiers,
+    :tiers_mode,
+    :transform_quantity,
+    :type,
+    :unit_amount,
+    :amount_decimal
+  ]
+
+  @plural_endpoint "prices"
+
+  @doc """
+  Create a price.
+  """
+  @spec create(params, Stripe.options()) ::
+          {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 :currency => String.t(),
+                 optional(:unit_amount) => pos_integer,
+                 optional(:active) => boolean,
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:nickname) => String.t(),
+                 optional(:product) => Stripe.id() | Stripe.Product.t(),
+                 optional(:recurring) => recurring(),
+                 optional(:tiers) => [price_tier()],
+                 optional(:tiers_mode) => String.t(),
+                 optional(:billing_scheme) => String.t(),
+                 optional(:lookup_key) => String.t(),
+                 optional(:transfer_lookup_key) => boolean,
+                 optional(:transform_quantity) => transform_quantity(),
+                 optional(:unit_amount_decimal) => String.t()
+               }
+               | %{}
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> cast_to_id([:product])
+    |> make_request()
+  end
+
+  @doc """
+  Retrieve a price.
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Update a price.
+
+  Takes the `id` and a map of changes.
+  """
+  @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:active) => boolean,
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:nickname) => String.t(),
+                 optional(:recurring) => recurring(),
+                 optional(:lookup_key) => String.t(),
+                 optional(:transfer_lookup_key) => boolean
+               }
+               | %{}
+  def update(id, params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  List all prices.
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:active) => boolean,
+                 optional(:currency) => String.t(),
+                 optional(:product) => Stripe.Product.t() | Stripe.id(),
+                 optional(:type) => String.t(),
+                 optional(:created) => Stripe.timestamp(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:limit) => 1..100,
+                 optional(:lookup_keys) => String.t(),
+                 optional(:recurring) => recurring() | nil,
+                 optional(:starting_after) => t | Stripe.id()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:product, :ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -103,6 +103,7 @@ defmodule Stripe.Mixfile do
         Stripe.FileUpload,
         Stripe.PaymentIntent,
         Stripe.Payout,
+        Stripe.Price,
         Stripe.Product,
         Stripe.Refund,
         Stripe.SetupIntent,

--- a/test/stripe/core_resources/price_test.exs
+++ b/test/stripe/core_resources/price_test.exs
@@ -1,0 +1,74 @@
+defmodule Stripe.PriceTest do
+  use Stripe.StripeCase, async: true
+
+  describe "create/2" do
+    test "creates a one-time Price for a product" do
+      params = %{
+        currency: "usd",
+        unit_amount: 5000,
+        product: "abc_123"
+      }
+
+      assert {:ok, %Stripe.Price{}} = Stripe.Price.create(params)
+      assert_stripe_requested(:post, "/v1/prices")
+    end
+
+    test "creates a recurring Price for a product" do
+      params = %{
+        currency: "usd",
+        unit_amount: 5000,
+        nickname: "Sapphire elite",
+        product: "abc_123",
+        recurring: %{
+          interval: "month",
+          trial_period_days: 10
+        }
+      }
+
+      assert {:ok, %Stripe.Price{}} = Stripe.Price.create(params)
+      assert_stripe_requested(:post, "/v1/prices")
+    end
+
+    test "creates a Price for a product with tiers" do
+      params = %{
+        currency: "usd",
+        unit_amount: 5000,
+        nickname: "Sapphire elite",
+        product: "abc_123",
+        recurring: %{
+          interval: "month",
+          trial_period_days: 10
+        },
+        billing_scheme: "tiered",
+        tiers: [%{unit_amount: 10, up_to: 12}]
+      }
+
+      assert {:ok, %Stripe.Price{}} = Stripe.Price.create(params)
+      assert_stripe_requested(:post, "/v1/prices")
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a Price" do
+      assert {:ok, %Stripe.Price{}} = Stripe.Price.retrieve("sapphire-elite")
+      assert_stripe_requested(:get, "/v1/prices/sapphire-elite")
+    end
+  end
+
+  describe "update/2" do
+    test "updates a Price" do
+      params = %{metadata: %{foo: "bar"}}
+      assert {:ok, price} = Stripe.Price.update("sapphire-elite", params)
+      assert_stripe_requested(:post, "/v1/prices/#{price.id}")
+    end
+  end
+
+  describe "list/2" do
+    test "lists all Prices" do
+      assert {:ok, %Stripe.List{data: prices}} = Stripe.Price.list()
+      assert_stripe_requested(:get, "/v1/prices")
+      assert is_list(prices)
+      assert %Stripe.Price{} = hd(prices)
+    end
+  end
+end

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -24,6 +24,7 @@ defmodule Stripe.UtilTest do
       assert object_name_to_module("order_return") == Stripe.OrderReturn
       assert object_name_to_module("payment_intent") == Stripe.PaymentIntent
       assert object_name_to_module("plan") == Stripe.Plan
+      assert object_name_to_module("price") == Stripe.Price
       assert object_name_to_module("product") == Stripe.Product
       assert object_name_to_module("refund") == Stripe.Refund
       assert object_name_to_module("setup_intent") == Stripe.SetupIntent


### PR DESCRIPTION
Stripe has a new, and recommended, way to deal with prices for both recurring and one-time purchases of products.

API doc: https://stripe.com/docs/api/prices
Guide: https://stripe.com/docs/billing/prices-guide
Migration Guide: https://stripe.com/docs/billing/migration/migrating-prices