### PR TITLE
Add support for BillingPortal.Session

### DIFF
--- a/lib/stripe/billing_portal/session.ex
+++ b/lib/stripe/billing_portal/session.ex
@@ -1,0 +1,50 @@
+defmodule Stripe.BillingPortal.Session do
+  @moduledoc """
+  Work with Stripe Billing (aka Self-serve) Portal Session objects.
+
+  You can:
+
+  - Create a session
+
+  Stripe API reference: https://stripe.com/docs/api/self_service_portal
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          :id => Stripe.id(),
+          :object => String.t(),
+          :created => Stripe.timestamp(),
+          :customer => Stripe.id() | Stripe.Customer.t(),
+          :livemode => boolean(),
+          :return_url => String.t(),
+          :url => String.t()
+        }
+
+  @type create_params :: %{
+          :customer => String.t(),
+          optional(:return_url) => String.t()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :created,
+    :customer,
+    :livemode,
+    :return_url,
+    :url
+  ]
+
+  @plural_endpoint "billing_portal/sessions"
+
+  @spec create(create_params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> make_request()
+  end
+end

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -18,6 +18,7 @@ defmodule Stripe.Converter do
     balance
     balance_transaction
     bank_account
+    billing_portal.session
     card
     charge
     checkout.session

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -51,6 +51,7 @@ defmodule Stripe.Util do
   def atomize_key(k), do: k
 
   @spec object_name_to_module(String.t()) :: module
+  def object_name_to_module("billing_portal.session"), do: Stripe.BillingPortal.Session
   def object_name_to_module("checkout.session"), do: Stripe.Session
   def object_name_to_module("file"), do: Stripe.FileUpload
   def object_name_to_module("issuing.authorization"), do: Stripe.Issuing.Authorization

--- a/mix.exs
+++ b/mix.exs
@@ -138,6 +138,9 @@ defmodule Stripe.Mixfile do
         Stripe.SubscriptionSchedule,
         Stripe.TaxRate
       ],
+      "Billing Portal": [
+        Stripe.BillingPortal.Session
+      ],
       Connect: [
         Stripe.Account,
         Stripe.ApplicationFee,

--- a/test/stripe/billing_portal/session_test.exs
+++ b/test/stripe/billing_portal/session_test.exs
@@ -1,0 +1,13 @@
+defmodule Stripe.BillingPortal.SessionTest do
+  use Stripe.StripeCase, async: true
+
+  test "is creatable" do
+    params = %{
+      customer: "cus_123",
+      return_url: "https://stripe.com"
+    }
+
+    assert {:ok, %Stripe.BillingPortal.Session{}} = Stripe.BillingPortal.Session.create(params)
+    assert_stripe_requested(:post, "/v1/billing_portal/sessions")
+  end
+end


### PR DESCRIPTION
This adds support for the Stripe Billing Portal Session.

https://stripe.com/docs/billing/subscriptions/integrating-self-serve-portal
https://stripe.com/docs/api/self_service_portal