### PR TITLE
Add price to Subscription

### DIFF
--- a/lib/stripe/subscriptions/line_item.ex
+++ b/lib/stripe/subscriptions/line_item.ex
@@ -29,6 +29,7 @@ defmodule Stripe.LineItem do
             end: Stripe.timestamp()
           },
           plan: Stripe.Plan.t() | nil,
+          price: Stripe.Price.t() | nil,
           proration: boolean,
           quantity: integer,
           subscription: Stripe.id() | nil,
@@ -50,6 +51,7 @@ defmodule Stripe.LineItem do
     :metadata,
     :period,
     :plan,
+    :price,
     :proration,
     :quantity,
     :subscription,

--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -269,7 +269,7 @@ defmodule Stripe.Subscription do
                optional(:ending_before) => t | Stripe.id(),
                optional(:limit) => 1..100,
                optional(:plan) => Stripe.Plan.t() | Stripe.id(),
-               optional(:price) => Stripe.Price.t() |Stripe.id(),
+               optional(:price) => Stripe.Price.t() | Stripe.id(),
                optional(:starting_after) => t | Stripe.id(),
                optional(:status) => String.t()
              }

--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -135,7 +135,8 @@ defmodule Stripe.Subscription do
                optional(:days_until_due) => non_neg_integer,
                :items => [
                  %{
-                   :plan => Stripe.id() | Stripe.Plan.t(),
+                   optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+                   optional(:price) => Stripe.id() | Stripe.Price.t(),
                    optional(:billing_methods) => map,
                    optional(:metadata) => map,
                    optional(:quantity) => non_neg_integer,
@@ -190,8 +191,9 @@ defmodule Stripe.Subscription do
                optional(:days_until_due) => non_neg_integer,
                optional(:items) => [
                  %{
-                   :plan => Stripe.id() | Stripe.Plan.t(),
                    optional(:id) => Stripe.id() | binary(),
+                   optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+                   optional(:price) => Stripe.id() | Stripe.Price.t(),
                    optional(:billing_methods) => map,
                    optional(:metadata) => map,
                    optional(:quantity) => non_neg_integer,
@@ -267,6 +269,7 @@ defmodule Stripe.Subscription do
                optional(:ending_before) => t | Stripe.id(),
                optional(:limit) => 1..100,
                optional(:plan) => Stripe.Plan.t() | Stripe.id(),
+               optional(:price) => Stripe.Price.t() |Stripe.id(),
                optional(:starting_after) => t | Stripe.id(),
                optional(:status) => String.t()
              }
@@ -276,7 +279,7 @@ defmodule Stripe.Subscription do
     |> put_endpoint(@plural_endpoint)
     |> put_method(:get)
     |> put_params(params)
-    |> cast_to_id([:customer, :ending_before, :plan, :starting_after])
+    |> cast_to_id([:customer, :ending_before, :plan, :price, :starting_after])
     |> make_request()
   end
 

--- a/lib/stripe/subscriptions/subscription_item.ex
+++ b/lib/stripe/subscriptions/subscription_item.ex
@@ -16,6 +16,7 @@ defmodule Stripe.SubscriptionItem do
           deleted: boolean | nil,
           metadata: Stripe.Types.metadata(),
           plan: Stripe.Plan.t(),
+          price: Stripe.Price.t(),
           quantity: non_neg_integer,
           subscription: Stripe.id() | Stripe.Subscription.t() | nil,
           tax_rates: list(Stripe.TaxRate.t())
@@ -29,6 +30,7 @@ defmodule Stripe.SubscriptionItem do
     :deleted,
     :metadata,
     :plan,
+    :price,
     :quantity,
     :subscription,
     :tax_rates
@@ -41,20 +43,21 @@ defmodule Stripe.SubscriptionItem do
   """
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params: %{
-               :plan => Stripe.id() | Stripe.Plan.t(),
                :subscription => Stripe.id() | Stripe.Subscription.t(),
+               optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+               optional(:price) => Stripe.id() | Stripe.Price.t(),
                optional(:metadata) => Stripe.Types.metadata(),
                optional(:prorate) => boolean,
                optional(:proration_date) => Stripe.timestamp(),
                optional(:quantity) => float,
                optional(:tax_rates) => list(String.t())
              }
-  def create(%{plan: _, subscription: _} = params, opts \\ []) do
+  def create(%{subscription: _} = params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint)
     |> put_params(params)
     |> put_method(:post)
-    |> cast_to_id([:plan, :subscription])
+    |> cast_to_id([:plan, :price, :subscription])
     |> make_request()
   end
 
@@ -78,6 +81,7 @@ defmodule Stripe.SubscriptionItem do
         when params: %{
                optional(:metadata) => Stripe.Types.metadata(),
                optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+               optional(:price) => Stripe.id() | Stripe.Price.t(),
                optional(:prorate) => boolean,
                optional(:proration_date) => Stripe.timestamp(),
                optional(:quantity) => float,
@@ -88,7 +92,7 @@ defmodule Stripe.SubscriptionItem do
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
     |> put_method(:post)
     |> put_params(params)
-    |> cast_to_id([:plan])
+    |> cast_to_id([:plan, :price])
     |> make_request()
   end
 

--- a/lib/stripe/subscriptions/subscription_schedule.ex
+++ b/lib/stripe/subscriptions/subscription_schedule.ex
@@ -9,6 +9,7 @@ defmodule Stripe.SubscriptionSchedule do
 
   @type plans :: %{
           plan: String.t(),
+          price: String.t(),
           quantity: pos_integer
         }
 
@@ -99,7 +100,8 @@ defmodule Stripe.SubscriptionSchedule do
                  %{
                    :plans => [
                      %{
-                       :plan => Stripe.id() | Stripe.Plan.t(),
+                       optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+                       optional(:price) => Stripe.id() | Stripe.Price.t(),
                        optional(:quantity) => non_neg_integer
                      }
                    ],
@@ -152,7 +154,8 @@ defmodule Stripe.SubscriptionSchedule do
                  %{
                    :plans => [
                      %{
-                       :plan => Stripe.id() | Stripe.Plan.t(),
+                       optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+                       optional(:price) => Stripe.id() | Stripe.Price.t(),
                        optional(:quantity) => non_neg_integer
                      }
                    ],


### PR DESCRIPTION
Subscriptions can have either `plan` or `price` attributes. Because of that, the documentation states that the `plan` parameter is optional when creating or updating subscriptions.

I missed to modify this module when created the `Price` module on my previous PR (#603).