### PR TITLE
makes `:previous_attributes` in `Event.event_data` optional

### DIFF
--- a/lib/stripe/core_resources/event.ex
+++ b/lib/stripe/core_resources/event.ex
@@ -13,8 +13,8 @@ defmodule Stripe.Event do
   import Stripe.Request
 
   @type event_data :: %{
-          object: event_data_object,
-          previous_attributes: map
+          :object => event_data_object,
+          optional(:previous_attributes) => map
         }
 
   # TODO: add Scheduled query run


### PR DESCRIPTION
according to https://stripe.com/docs/api/events/object , `data.previous_attributes` is "sent along only with *.updated events"