### PR TITLE
Fix multiple Stripe-Version headers when creating ephemeral key

### DIFF
--- a/lib/stripe/ephemeral_key.ex
+++ b/lib/stripe/ephemeral_key.ex
@@ -12,8 +12,8 @@ defmodule Stripe.EphemeralKey do
   but is required for iOS and Android SDK functionality.
 
   Explained in
-  https://stripe.com/docs/mobile/ios/standard#prepare-your-api
-  https://stripe.com/docs/mobile/android/customer-information#prepare-your-api
+  https://stripe.com/docs/mobile/ios/basic#ephemeral-key
+  https://stripe.com/docs/mobile/android/basic#set-up-ephemeral-key
 
   Stripe API reference: https://stripe.com/docs/api#customer
   """
@@ -41,7 +41,7 @@ defmodule Stripe.EphemeralKey do
                :customer => Stripe.id()
              }
   def create(params, api_version, opts \\ []) do
-    new_request(opts, %{"Stripe-Version": api_version})
+    new_request([api_version: api_version] ++ opts)
     |> put_endpoint(@plural_endpoint)
     |> put_params(params)
     |> put_method(:post)


### PR DESCRIPTION
Creating an ephemeral key requires passing in a Stripe API version given by the iOS or Android SDK (see [documentation](https://stripe.com/docs/mobile/ios/basic#ephemeral-key)). However, `Stripe.EphemeralKey.create` returns an error because multiple `Stripe-Version` headers are sent.

```elixir
Stripe.EphemeralKey.create(%{customer: "cus_xxxxxxxxxxxxxx"}, "2019-05-16")
```
```elixir
{:error,
 %Stripe.Error{
   code: :invalid_request_error,
   extra: %{
     http_status: 400,
     raw_error: %{
       "message" => "Invalid Stripe API version: 2019-05-16, 2019-12-03",
       "type" => "invalid_request_error"
     }
   },
   message: "Invalid Stripe API version: 2019-05-16, 2019-12-03",
   request_id: nil,
   source: :stripe,
   user_message: nil
 }}
```

This pull request overrides the default API version set using the one passed in, and updates links to the latest documentation.

Fixes #606.