### PR TITLE
Add :metadata to Stripe.Session.create/2

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -65,6 +65,7 @@ defmodule Stripe.Session do
           optional(:customer_email) => String.t(),
           optional(:line_items) => list(line_item),
           optional(:locale) => String.t(),
+          optional(:metadata) => Stripe.Types.metadata(),
           optional(:payment_intent_data) => payment_intent_data,
           optional(:subscription_data) => subscription_data
         }


### PR DESCRIPTION
https://stripe.com/docs/api/checkout/sessions/create includes a top level `metadata` key that this library was missing.