### PR TITLE
support extra params for subscription cancellation

### DIFF
--- a/test/stripe/subscriptions/subscription_test.exs
+++ b/test/stripe/subscriptions/subscription_test.exs
@@ -74,6 +74,13 @@ defmodule Stripe.SubscriptionTest do
       assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
     end
 
+    test "deletes a subscription when second argument is a map" do
+      assert {:ok, %Stripe.Subscription{} = subscription} =
+               Stripe.Subscription.delete("sub_123", %{})
+
+      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
+    end
+
     test "with `at_period_end` is deprecated [since 2018-08-23]" do
       assert {:ok, %Stripe.Subscription{} = subscription} =
                Stripe.Subscription.delete("sub_123", %{at_period_end: true})
@@ -92,6 +99,15 @@ defmodule Stripe.SubscriptionTest do
 
       # The deprecated function acts as a facade for `cancel_at_period_end: true`.
       assert_stripe_requested(:post, "/v1/subscriptions/sub_123")
+    end
+
+    test "deletes a subscription with provided cancelation params" do
+      params = %{invoice_now: true, prorate: true}
+
+      assert {:ok, %Stripe.Subscription{} = subscription} =
+               Stripe.Subscription.delete("sub_123", params)
+
+      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}", body: params)
     end
   end
 


### PR DESCRIPTION
Hi stripity_stripe people :wave: 

This P/R adds support for cancelation params to `Stripe.Subscription.delete()`. It was originally reported in #617 and I was using a workaround myself. 

Example usage:

```elixir
{:ok, cancelled_subscription} = 
  Stripe.Subscription.delete(
    subscription_id,
    %{invoice_now: true}
  )
```

It's not clearly visible in the diff so here's a grep of function definitions / pattern matching at a glance:

```
  def delete(id)
  def delete(id, opts) when is_list(opts)
  def delete(id, %{at_period_end: true})
  def delete(id, params) when is_map(params)
  def delete(id, %{at_period_end: true}, opts)
  def delete(id, params, opts)
```

I was trying to keep it clean and consistent, but if you prefer it to be written differently let me know. Other feedback is welcome too of course :smile: 

All tests are passing and Dialyzer reports no issues. I also tested this on test servers and `Dashboard->Developer->Logs` did show the params were received as expected. Before it would fail to pattern match, as in #617.


Lastly, `Stripe.Subscription.delete |> h()` output:

![image](https://user-images.githubusercontent.com/853568/87887617-10a4ea00-ca27-11ea-91ff-9f2750a5d9e6.png)