### PR TITLE
Update link to Stripe docs in Stripe.BillingPortal.Session

### DIFF
--- a/lib/stripe/billing_portal/session.ex
+++ b/lib/stripe/billing_portal/session.ex
@@ -6,7 +6,7 @@ defmodule Stripe.BillingPortal.Session do
 
   - Create a session
 
-  Stripe API reference: https://stripe.com/docs/api/self_service_portal
+  Stripe API reference: https://stripe.com/docs/api/customer_portal
   """
 
   use Stripe.Entity


### PR DESCRIPTION
Looks like Stripe moved the page. I think this it the correct one