### PR TITLE
Add payment_method to confirm payment intent

### DIFF
--- a/lib/stripe/core_resources/payment_intent.ex
+++ b/lib/stripe/core_resources/payment_intent.ex
@@ -235,7 +235,8 @@ defmodule Stripe.PaymentIntent do
                  optional(:return_url) => String.t(),
                  optional(:save_payment_method) => boolean,
                  optional(:shipping) => Stripe.Types.shipping(),
-                 optional(:source) => Stripe.id() | Stripe.Card.t()
+                 optional(:source) => Stripe.id() | Stripe.Card.t(),
+                 optional(:payment_method) => Stripe.id() | Stripe.PaymentMethod.t()
                }
                | %{}
   def confirm(id, params, opts \\ []) do
@@ -243,6 +244,7 @@ defmodule Stripe.PaymentIntent do
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "/confirm")
     |> put_method(:post)
     |> put_params(params)
+    |> cast_to_id([:source, :payment_method])
     |> make_request()
   end
 


### PR DESCRIPTION
Allow confirming a payment intent using a payment method. This appears
to be the newest way of confirming a payment, deprecating the source
field.

I believe it's best to leave both options in for backwards compatibility

https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-payment_method

I also added in a cast_to_id call that appeared to be missing in the confirm function.