### PR TITLE
Adding endpoint for checkout session line items.

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -142,4 +142,6 @@ defmodule Stripe.Session do
     |> put_method(:get)
     |> make_request()
   end
+
+  defdelegate list_line_items(id, opts \\ []), to: Stripe.Checkout.Session.LineItems, as: :list
 end

--- a/lib/stripe/checkout/session/line_items.ex
+++ b/lib/stripe/checkout/session/line_items.ex
@@ -1,0 +1,42 @@
+defmodule Stripe.Checkout.Session.LineItems do
+  @moduledoc false
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          amount_subtotal: non_neg_integer,
+          amount_total: non_neg_integer,
+          currency: String.t(),
+          description: String.t(),
+          price: Stripe.Price.t(),
+          quantity: non_neg_integer
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :amount_subtotal,
+    :amount_total,
+    :currency,
+    :description,
+    :price,
+    :quantity
+  ]
+
+  @plural_endpoint "checkout/sessions"
+
+  @doc """
+  List line items on a checkout session.
+  """
+  @spec list(Stripe.id(), Stripe.options()) ::
+          {:ok, Stripe.List.t(t())} | {:error, Stripe.Error.t()}
+  def list(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}/" <> "line_items")
+    |> put_method(:get)
+    |> make_request()
+  end
+end

--- a/test/stripe/checkout/session_test.exs
+++ b/test/stripe/checkout/session_test.exs
@@ -18,4 +18,11 @@ defmodule Stripe.SessionTest do
       assert_stripe_requested(:get, "/v1/checkout/sessions/cs_123")
     end
   end
+
+  describe "list_line_items/2" do
+    test "lists line items" do
+      assert {:ok, %Stripe.List{}} = Stripe.Session.list_line_items("cs_123")
+      assert_stripe_requested(:get, "/v1/checkout/sessions/cs_123/line_items")
+    end
+  end
 end


### PR DESCRIPTION
Add an endpoint for listing the line items on a checkout session.

Documented here: https://stripe.com/docs/api/checkout/sessions/line_items