### PR TITLE
Add payment_intent to Stripe.Charge.params type

### DIFF
--- a/lib/stripe/core_resources/charge.ex
+++ b/lib/stripe/core_resources/charge.ex
@@ -319,7 +319,8 @@ defmodule Stripe.Charge do
                  optional(:object) => String.t()
                },
                optional(:starting_after) => t | Stripe.id(),
-               optional(:transfer_group) => String.t()
+               optional(:transfer_group) => String.t(),
+               optional(:payment_intent) => Stripe.PaymentIntent.t() | Stripe.id()
              }
   def list(params \\ %{}, opts \\ []) do
     new_request(opts)


### PR DESCRIPTION
The `payment_intent` parameter is supported by the API so here it's added to the typespec.