### PR TITLE
Add promotion_code to Discount

### DIFF
--- a/lib/stripe/subscriptions/discount.ex
+++ b/lib/stripe/subscriptions/discount.ex
@@ -14,7 +14,8 @@ defmodule Stripe.Discount do
           deleted: boolean | nil,
           end: Stripe.timestamp() | nil,
           start: Stripe.timestamp(),
-          subscription: Stripe.id() | nil
+          subscription: Stripe.id() | nil,
+          promotion_code: Stripe.id() | nil
         }
 
   defstruct [
@@ -24,6 +25,7 @@ defmodule Stripe.Discount do
     :deleted,
     :end,
     :start,
-    :subscription
+    :subscription,
+    :promotion_code
   ]
 end

--- a/test/fixtures/discount.json
+++ b/test/fixtures/discount.json
@@ -19,5 +19,6 @@
   "customer": "cus_DCUJlLSyrGaqab",
   "end": 1595517288,
   "start": 1532358888,
-  "subscription": "sub_DG9Uq9WOevR9Uo"
+  "subscription": "sub_DG9Uq9WOevR9Uo",
+  "promotion_code": "promo_1HuRNuKKEsQW5O8UAfIZ33ox"
 }

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -228,7 +228,8 @@ defmodule Stripe.ConverterTest do
       end: 1_595_517_288,
       object: "discount",
       start: 1_532_358_888,
-      subscription: "sub_DG9Uq9WOevR9Uo"
+      subscription: "sub_DG9Uq9WOevR9Uo",
+      promotion_code: "promo_1HuRNuKKEsQW5O8UAfIZ33ox"
     }
 
     fixture = Helper.load_fixture("discount.json")


### PR DESCRIPTION
Hello,

I need the `promotion_code` returned from Stripe objects (Subscription, Invoice, ect...) for a project I am working on and it gets removed from the payload since it is not defined in the Discount module. Adding this fixes my issue.

<img width="473" alt="Screen Shot 2020-12-10 at 6 40 08 PM" src="https://user-images.githubusercontent.com/20251602/101842935-22db0e00-3b17-11eb-95e1-6d54daee876e.png">

PS: Travis fails, however all the tests pass... Not sure what that is about, if it is something on my end please let me know but I have looked and could not figure it out. It complains and exits on something to do with `mix coveralls.travis`

<img width="962" alt="Screen Shot 2020-12-10 at 6 44 09 PM" src="https://user-images.githubusercontent.com/20251602/101843209-b44a8000-3b17-11eb-9601-2e4507fa9f64.png">



