### PR TITLE
Remove Duplicate @doc Tag In Usage.ex

### DIFF
--- a/lib/stripe/subscriptions/usage.ex
+++ b/lib/stripe/subscriptions/usage.ex
@@ -34,9 +34,6 @@ defmodule Stripe.SubscriptionItem.Usage do
   """
   def create(id, params, opts \\ [])
 
-  @doc """
-  Creates a usage record for a specified subscription item id and date, and fills it with a quantity.
-  """
   @spec create(Stripe.id(), params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params: %{
                :quantity => float | pos_integer | 0,


### PR DESCRIPTION
Removes a duplicate doc tag in the `Usage.ex` module that is causing a compiler warning.

![image](https://user-images.githubusercontent.com/29756611/102097605-2232c800-3df4-11eb-9f6d-3d038088a680.png)

Issue: https://github.com/code-corps/stripity_stripe/issues/632