### PR TITLE
Fix typespec for Stripe.Invoice.pay/3

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -366,7 +366,8 @@ defmodule Stripe.Invoice do
                  optional(:forgive) => boolean,
                  optional(:paid_out_of_band) => boolean,
                  optional(:payment_method) => String.t(),
-                 optional(:source) => Stripe.id() | Stripe.Source.t()
+                 optional(:source) => Stripe.id() | Stripe.Source.t(),
+                 optional(:off_session) => boolean
                }
                | %{}
   def pay(id, params, opts \\ []) do


### PR DESCRIPTION
Stripe’s API support the off_session parameter, so the typespec should
include it too.

https://stripe.com/docs/api/invoices/pay