### PR TITLE
Support :status param in typespec for Stripe.Invoice.list/2

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -310,7 +310,8 @@ defmodule Stripe.Invoice do
                  optional(:ending_before) => t | Stripe.id(),
                  optional(:limit) => 1..100,
                  optional(:starting_after) => t | Stripe.id(),
-                 optional(:subscription) => Stripe.id() | Stripe.Subscription.t()
+                 optional(:subscription) => Stripe.id() | Stripe.Subscription.t(),
+                 optional(:status) => String.t()
                }
                | %{}
   def list(params \\ %{}, opts \\ []) do


### PR DESCRIPTION
This is supported by the Stripe API, but was missing from the typespec.