### PR TITLE
Add source_type to parameter types for transfers/create

### DIFF
--- a/lib/stripe/connect/transfer.ex
+++ b/lib/stripe/connect/transfer.ex
@@ -61,7 +61,8 @@ defmodule Stripe.Transfer do
                optional(:metadata) => Stripe.Types.metadata(),
                optional(:source_transaction) => Stripe.id() | Stripe.Charge.t(),
                optional(:transfer_group) => String.t(),
-               optional(:description) => String.t()
+               optional(:description) => String.t(),
+               optional(:source_type) => String.t()
              }
   def create(%{amount: _, currency: _, destination: _} = params, opts \\ []) do
     new_request(opts)


### PR DESCRIPTION
The API supports the `source_type` parameter when creating a transfer,
but the type restrictions don't currently list it. This causes a warning
in Dialyzer when passing the `source_type` parameter.

https://stripe.com/docs/api/transfers/create