### PR TITLE
Add credit note preview

### DIFF
--- a/lib/stripe/subscriptions/credit_note.ex
+++ b/lib/stripe/subscriptions/credit_note.ex
@@ -4,6 +4,7 @@ defmodule Stripe.CreditNote do
 
   You can:
 
+  - Preview a credit note
   - Create a credit note
   - Retrieve a credit note
   - Update a credit note
@@ -77,6 +78,34 @@ defmodule Stripe.CreditNote do
   ]
 
   @plural_endpoint "credit_notes"
+
+  @doc """
+  Preview a credit note.
+    Stripe.CreditNote.preview(%{
+      invoice: "in_173uNd4Wq104wst7Gf4dgq1Y",
+      amount: 500,
+    })
+  """
+  @spec preview(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 :amount => number,
+                 :invoice => Stripe.id(),
+                 optional(:credit_amount) => number,
+                 optional(:memo) => String.t(),
+                 optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:reason) => String.t(),
+                 optional(:refund_amount) => number,
+                 optional(:refund) => Stripe.id()
+               }
+               | %{}
+  def preview(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/preview")
+    |> put_params(params)
+    |> put_method(:get)
+    |> make_request()
+  end
 
   @doc """
   Create a credit note.

--- a/test/stripe/subscriptions/credit_note_test.exs
+++ b/test/stripe/subscriptions/credit_note_test.exs
@@ -2,6 +2,18 @@ defmodule Stripe.CreditNoteTest do
   use Stripe.StripeCase, async: true
   doctest Stripe.CreditNote
 
+  describe "preview/2" do
+    test "previews a Credit Note for a customer" do
+      params = %{
+        invoice: "in_173uNd4Wq104wst7Gf4dgq1Y",
+        amount: 500
+      }
+
+      assert {:ok, %Stripe.CreditNote{}} = Stripe.CreditNote.preview(params)
+      assert_stripe_requested(:get, "/v1/credit_notes/preview?amount=500&invoice=in_173uNd4Wq104wst7Gf4dgq1Y")
+    end
+  end
+
   describe "create/2" do
     test "creates a Credit Note for a customer" do
       params = %{

--- a/test/stripe/subscriptions/credit_note_test.exs
+++ b/test/stripe/subscriptions/credit_note_test.exs
@@ -10,7 +10,11 @@ defmodule Stripe.CreditNoteTest do
       }
 
       assert {:ok, %Stripe.CreditNote{}} = Stripe.CreditNote.preview(params)
-      assert_stripe_requested(:get, "/v1/credit_notes/preview?amount=500&invoice=in_173uNd4Wq104wst7Gf4dgq1Y")
+
+      assert_stripe_requested(
+        :get,
+        "/v1/credit_notes/preview?amount=500&invoice=in_173uNd4Wq104wst7Gf4dgq1Y"
+      )
     end
   end
 


### PR DESCRIPTION
Hello

I've noticed that the Preview action for Credit Notes is missing:

https://stripe.com/docs/api/credit_notes/preview

The required params are the same as the Create action. It just changes to a different endpoint and the method is a :get instead of a :post

I've added it on the top of the module to keep the same order as it shows up on Stripe's API documentation.

Thanks for the great lib!