### PR TITLE
Update typespec for Stripe.Customer

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -98,7 +98,7 @@ defmodule Stripe.Invoice do
           })
 
   @type invoice_settings :: %{
-          optional(:default_payment_method) => String.t(),
+          optional(:default_payment_method) => String.t() | Stripe.PaymentMethod.t(),
           optional(:custom_fields) => custom_fields,
           optional(:footer) => String.t()
         }


### PR DESCRIPTION
Ran into a warning saying no local return. This should fix it.

When `expand: ["invoice_settings.default_payment_method"]` is used with `Stripe.Customer.retrieve/2`, the typespec is incorrect.