### PR TITLE
Allow api_version to be set from config

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -63,6 +63,11 @@ defmodule Stripe.API do
     Config.resolve(:api_key, "")
   end
 
+  @spec get_api_version() :: String.t()
+  defp get_api_version() do
+    Config.resolve(:api_version, @api_version)
+  end
+
   @spec use_pool?() :: boolean
   defp use_pool?() do
     Config.resolve(:use_connection_pool)
@@ -178,7 +183,8 @@ defmodule Stripe.API do
   end
 
   @spec add_api_version(headers, String.t() | nil) :: headers
-  defp add_api_version(existing_headers, nil), do: add_api_version(existing_headers, @api_version)
+  defp add_api_version(existing_headers, nil),
+    do: add_api_version(existing_headers, get_api_version())
 
   defp add_api_version(existing_headers, api_version) do
     Map.merge(existing_headers, %{


### PR DESCRIPTION
The docs states you should be able to set api_version through config, as far as I can tell this should be valid:

```
config :stripity_stripe,
  api_version: "2020-08-27",
  api_key: "sk_test_xxx"
```

However api_version is not read. With this change it is.