### PR TITLE
Add mode to Session Create Params typespec

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -60,6 +60,7 @@ defmodule Stripe.Session do
           :cancel_url => String.t(),
           :payment_method_types => list(String.t()),
           :success_url => String.t(),
+          optional(:mode) => String.t(),
           optional(:client_reference_id) => String.t(),
           optional(:customer) => String.t(),
           optional(:customer_email) => String.t(),


### PR DESCRIPTION
`mode` is now required conditionally (or optional) when using prices in the line items. This PR will fix the failing dialyzer when including `mode` in the `create_params`.

Source: https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-mode