### PR TITLE
Switch :crypto.hmac/3 for :crypto.mac/4 for OTP 24

### DIFF
--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -116,7 +116,7 @@ defmodule Stripe.Webhook do
   end
 
   defp compute_signature(payload, secret) do
-    :crypto.hmac(:sha256, secret, payload)
+    :crypto.mac(:hmac, :sha256, secret, payload)
     |> Base.encode16(case: :lower)
   end
 

--- a/test/stripe/webhook_test.exs
+++ b/test/stripe/webhook_test.exs
@@ -11,7 +11,7 @@ defmodule Stripe.WebhookTest do
   @secret "secret"
 
   defp generate_signature(timestamp, payload, secret \\ @secret) do
-    :crypto.hmac(:sha256, secret, "#{timestamp}.#{payload}")
+    :crypto.mac(:hmac, :sha256, secret, "#{timestamp}.#{payload}")
     |> Base.encode16(case: :lower)
   end
 


### PR DESCRIPTION
I was testing out OTP 24 RC2 and noticed that [:crypto.hmac/3 is deprecated](https://erlang.org/doc/man/crypto.html#hmac-3) in favor of [:crypto.mac/4](https://erlang.org/doc/man/crypto.html#mac-4).

This function looks to have been [deprecated with the release of OTP 22](https://erlang.org/doc/general_info/deprecations.html#functions-deprecated-in-otp-22). Not sure what version of OTP this project aims to support, so just a heads up in case you are trying to keep OTP 21 compatibility.