### PR TITLE
Remove `customer` from `params` typespec in CustomerBalanceTransaction.create

### DIFF
--- a/lib/stripe/subscriptions/customer_balance_transaction.ex
+++ b/lib/stripe/subscriptions/customer_balance_transaction.ex
@@ -62,7 +62,6 @@ defmodule Stripe.CustomerBalanceTransaction do
           {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
-                 :customer => Stripe.id() | Stripe.Customer.t(),
                  :amount => number,
                  :currency => String.t(),
                  optional(:description) => String.t(),


### PR DESCRIPTION
Prior to this PR, the only valid way to use this function would return a dialyzer error.

It's invalid to pass the `customer` ID as both part of the URL (which
this function does) *and* in the body. Doing so leads to a Stripe
error:

```elixir
iex(1)> Stripe.CustomerBalanceTransaction.create("cus_JO4D6sa5xl4Uk7", %{amount: -100, currency: "USD", customer: "cus_JO4D6sa5xl4Uk7"})
{:error,
 %Stripe.Error{
   code: :invalid_request_error,
   extra: %{
     http_status: 400,
     param: :customer,
     raw_error: %{
       "message" => "A parameter provided in the URL (customer) was repeated as a GET or POST parameter. You can only provide this information as a portion of the URL.",
       "param" => "customer",
       "type" => "invalid_request_error"
     }
   },
   message: "A parameter provided in the URL (customer) was repeated as a GET or POST parameter. You can only provide this information as a portion of the URL.",
   request_id: nil,
   source: :stripe,
   user_message: nil
 }}
```

Whereas passing it as the first (required) positional argument works
fine:

```elixir
iex(2)> Stripe.CustomerBalanceTransaction.create("cus_JO4D6sa5xl4Uk7", %{amount: -100, currency: "USD"})
{:ok,
 %Stripe.CustomerBalanceTransaction{
   amount: -100,
   created: 1619635421,
   credit_note: nil,
   currency: "usd",
   customer: "cus_JO4D6sa5xl4Uk7",
   description: nil,
   ending_balance: -100,
   id: "cbtxn_1IlIMLFvgMYR2X5ykmdTnR5H",
   invoice: nil,
   livemode: false,
   metadata: %{},
   object: "customer_balance_transaction",
   type: "adjustment"
 }}
```

(the customer here is a throwaway user in my test account)