### PR TITLE
Fix Stripe.Price unit_amount_decimal and lookup_keys type

### DIFF
--- a/lib/stripe/subscriptions/price.ex
+++ b/lib/stripe/subscriptions/price.ex
@@ -201,7 +201,7 @@ defmodule Stripe.Price do
                  optional(:created) => Stripe.timestamp(),
                  optional(:ending_before) => t | Stripe.id(),
                  optional(:limit) => 1..100,
-                 optional(:lookup_keys) => String.t(),
+                 optional(:lookup_keys) => list(String.t()),
                  optional(:recurring) => recurring() | nil,
                  optional(:starting_after) => t | Stripe.id()
                }

--- a/lib/stripe/subscriptions/price.ex
+++ b/lib/stripe/subscriptions/price.ex
@@ -95,7 +95,7 @@ defmodule Stripe.Price do
           transform_quantity: transform_quantity(),
           type: String.t(),
           unit_amount: pos_integer,
-          amount_decimal: String.t()
+          unit_amount_decimal: String.t()
         }
 
   defstruct [
@@ -116,7 +116,7 @@ defmodule Stripe.Price do
     :transform_quantity,
     :type,
     :unit_amount,
-    :amount_decimal
+    :unit_amount_decimal
   ]
 
   @plural_endpoint "prices"


### PR DESCRIPTION
1. Fix spec for price lookup_keys type as list
https://stripe.com/docs/api/prices/list#list_prices-lookup_keys
eg. https://api.stripe.com/v1/prices?lookup_keys[0]=key0&lookup_keys[1]=key1

2. Fix Stripe.Price struct unit_amount_decimal
instead of amount_decimal (Ref: https://stripe.com/docs/api/prices/retrieve)