### PR TITLE
fix(deprecation): :crypto.hmac -> :crypto.mac, Bitwise.^^^ -> Bitwise.bxor

### DIFF
--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -116,8 +116,15 @@ defmodule Stripe.Webhook do
   end
 
   defp compute_signature(payload, secret) do
-    :crypto.hmac(:sha256, secret, payload)
+    hmac(:sha256, secret, payload)
     |> Base.encode16(case: :lower)
+  end
+
+  # TODO: remove when we require OTP 22
+  if System.otp_release() >= "22" do
+    defp hmac(digest, key, data), do: :crypto.mac(:hmac, digest, key, data)
+  else
+    defp hmac(digest, key, data), do: :crypto.hmac(digest, key, data)
   end
 
   defp secure_equals?(input, expected) when byte_size(input) == byte_size(expected) do
@@ -135,7 +142,7 @@ defmodule Stripe.Webhook do
     import Bitwise
 
     acc
-    |> bor(input_codepoint ^^^ expected_codepoint)
+    |> bor(bxor(input_codepoint, expected_codepoint))
     |> secure_compare(input, expected)
   end
 

--- a/test/stripe/webhook_test.exs
+++ b/test/stripe/webhook_test.exs
@@ -11,8 +11,15 @@ defmodule Stripe.WebhookTest do
   @secret "secret"
 
   defp generate_signature(timestamp, payload, secret \\ @secret) do
-    :crypto.hmac(:sha256, secret, "#{timestamp}.#{payload}")
+    hmac(:sha256, secret, "#{timestamp}.#{payload}")
     |> Base.encode16(case: :lower)
+  end
+
+  # TODO: remove when we require OTP 22
+  if System.otp_release() >= "22" do
+    defp hmac(digest, key, data), do: :crypto.mac(:hmac, digest, key, data)
+  else
+    defp hmac(digest, key, data), do: :crypto.hmac(digest, key, data)
   end
 
   defp create_signature_header(timestamp, scheme, signature) do


### PR DESCRIPTION
Related to PR https://github.com/code-corps/stripity_stripe/pull/661#issuecomment-812900413 to support OTP 24

- fixes deprecation for `:cryto.hmac/3` with backward compatibility prior to OTP 22
- fixes deprecation warning for Bitwise.^^^ usage