### PR TITLE
Subscription Item: Inconsistency

### DIFF
--- a/lib/stripe/subscriptions/subscription_item.ex
+++ b/lib/stripe/subscriptions/subscription_item.ex
@@ -49,7 +49,7 @@ defmodule Stripe.SubscriptionItem do
                optional(:metadata) => Stripe.Types.metadata(),
                optional(:prorate) => boolean,
                optional(:proration_date) => Stripe.timestamp(),
-               optional(:quantity) => float,
+               optional(:quantity) => non_neg_integer,
                optional(:tax_rates) => list(String.t())
              }
   def create(%{subscription: _} = params, opts \\ []) do
@@ -84,7 +84,7 @@ defmodule Stripe.SubscriptionItem do
                optional(:price) => Stripe.id() | Stripe.Price.t(),
                optional(:prorate) => boolean,
                optional(:proration_date) => Stripe.timestamp(),
-               optional(:quantity) => float,
+               optional(:quantity) => non_neg_integer,
                optional(:tax_rates) => list(String.t())
              }
   def update(id, params, opts \\ []) do


### PR DESCRIPTION
While using Stripe.SubscriptionItem.create(), quantity with parameter as non_neg_integer as defined in typespec gives error in mix check and in API call as inside function it shows parameter as float

<img width="711" alt="Screenshot 2021-07-25 at 11 51 23 PM" src="https://user-images.githubusercontent.com/40158831/126909247-d988f7b7-a16c-4bde-97c7-2bc16542d97b.png">

Stripe official documentation:

<img width="1421" alt="Screenshot 2021-07-26 at 12 00 53 AM" src="https://user-images.githubusercontent.com/40158831/126909534-8d4c26f0-cdc7-43ae-93ae-816ebe2582a4.png">


