### PR TITLE
Add the issuing field to Stripe.Balance

### DIFF
--- a/lib/stripe/core_resources/balance.ex
+++ b/lib/stripe/core_resources/balance.ex
@@ -17,10 +17,20 @@ defmodule Stripe.Balance do
           }
         }
 
+  @type issuing_funds :: %{
+          currency: String.t(),
+          amount: integer
+        }
+
+  @type issuing :: %{
+          available: list(issuing_funds)
+        }
+
   @type t :: %__MODULE__{
           object: String.t(),
           available: list(funds),
           connect_reserved: list(funds) | nil,
+          issuing: issuing,
           livemode: boolean,
           pending: list(funds)
         }
@@ -29,6 +39,7 @@ defmodule Stripe.Balance do
     :object,
     :available,
     :connect_reserved,
+    :issuing,
     :livemode,
     :pending
   ]


### PR DESCRIPTION
The `Stripe.Balance` is currently missing the `issuing` field for Issuing Balance. This PR adds it and closes #560 