### PR TITLE
Add application to webhook_endpoint

### DIFF
--- a/lib/stripe/core_resources/webhook_endpoint.ex
+++ b/lib/stripe/core_resources/webhook_endpoint.ex
@@ -13,6 +13,7 @@ defmodule Stripe.WebhookEndpoint do
   require Stripe.Util
 
   @type t :: %__MODULE__{
+          application: String.t() | nil,
           created: Stripe.timestamp(),
           deleted: boolean,
           description: String.t(),
@@ -27,6 +28,7 @@ defmodule Stripe.WebhookEndpoint do
         }
 
   defstruct [
+    :application,
     :created,
     :deleted,
     :description,


### PR DESCRIPTION
Add the `application` field to the webhook endpoint struct.

https://stripe.com/docs/api/webhook_endpoints/object#webhook_endpoint_object-application