### PR TITLE
Add missing opts to Stripe.ApplicationFee

### DIFF
--- a/lib/stripe/connect/application_fee.ex
+++ b/lib/stripe/connect/application_fee.ex
@@ -47,9 +47,9 @@ defmodule Stripe.ApplicationFee do
   @doc """
   Retrieves the details of the application fees
   """
-  @spec retrieve(Stripe.id()) :: {:ok, t} | {:error, Stripe.Error.t()}
-  def retrieve(id) do
-    new_request()
+  @spec retrieve(Stripe.id(), Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
     |> put_endpoint(@endpoint <> "/#{get_id!(id)}")
     |> put_method(:get)
     |> make_request()


### PR DESCRIPTION
Since now it's impossible to retrieve application fee with given api key.

Trying current version of the function results in:

```
You did not provide an API key. You need to provide your API key in the Authorization header, using Bearer auth (e.g. 'Authorization: Bearer YOUR_SECRET_KEY'). See https://stripe.com/docs/api#authentication for details, or we can help at https://support.stripe.com/.
```