### PR TITLE
Adds expiry feature 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
          otp: [24]
     services:
        stripe-mock:
-         image: stripemock/stripe-mock:v0.110.0
+         image: stripemock/stripe-mock:v0.116.0
          ports:
            - 12111:12111
            - 12112:12112

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     env:
       MIX_ENV: test
-      STRIPE_MOCK_VERSION: 0.110.0
+      STRIPE_MOCK_VERSION: 0.116.0
       STRIPE_SECRET_KEY: non_empty_string
       SKIP_STRIPE_MOCK_RUN: true
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
          otp: [24]
     services:
        stripe-mock:
-         image: stripemock/stripe-mock:v0.116.0
+         image: stripe/stripe-mock:v0.116.0
          ports:
            - 12111:12111
            - 12112:12112

--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -360,5 +360,16 @@ defmodule Stripe.Session do
     |> make_request()
   end
 
+  @doc """
+  Invalidates a session
+  """
+  @spec expire(Stripe.id() | t) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def expire(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}/expire")
+    |> put_method(:post)
+    |> make_request()
+  end
+
   defdelegate list_line_items(id, opts \\ []), to: Stripe.Checkout.Session.LineItems, as: :list
 end

--- a/test/stripe/checkout/session_test.exs
+++ b/test/stripe/checkout/session_test.exs
@@ -19,10 +19,10 @@ defmodule Stripe.SessionTest do
     end
   end
 
-  describe "expire" do
+  describe "expire/2" do
     test "expires a session" do
       assert {:ok, session = %Stripe.Session{}} = Stripe.Session.expire("cs_123")
-      assert_stripe_requested(:post, "/v1/checkout/sessions/cs_123")
+      assert_stripe_requested(:post, "/v1/checkout/sessions/cs_123/expire")
     end
   end
 

--- a/test/stripe/checkout/session_test.exs
+++ b/test/stripe/checkout/session_test.exs
@@ -19,6 +19,13 @@ defmodule Stripe.SessionTest do
     end
   end
 
+  describe "expire" do
+    test "expires a session" do
+      assert {:ok, session = %Stripe.Session{}} = Stripe.Session.expire("cs_123")
+      assert_stripe_requested(:post, "/v1/checkout/sessions/cs_123")
+    end
+  end
+
   describe "list_line_items/2" do
     test "lists line items" do
       assert {:ok, %Stripe.List{}} = Stripe.Session.list_line_items("cs_123")


### PR DESCRIPTION
## What's here?

- This expires a session provided an ID
- This is an important feature to prevent code overhead on duplicate payments caused by payment sessions

## Some other prerequisites included 

- Stripe Mock had to be upgraded to v0.116.0
- The docker image being pulled is now the official one hosted by Stripe. The old one seems to look unmaintained, with no one in sight to contact anyway.

## References

- https://stripe.com/docs/api/checkout/sessions/expire