### PR TITLE
sync "Products > Update a product" params typespec

### DIFF
--- a/lib/stripe/subscriptions/product.ex
+++ b/lib/stripe/subscriptions/product.ex
@@ -106,10 +106,13 @@ defmodule Stripe.Product do
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 optional(:active) => boolean,
                  optional(:attributes) => list,
-                 optional(:name) => String.t(),
+                 optional(:description) => String.t(),
                  optional(:metadata) => Stripe.Types.metadata(),
-                 optional(:statement_descriptor) => String.t()
+                 optional(:name) => String.t(),
+                 optional(:statement_descriptor) => String.t(),
+                 optional(:url) => String.t()
                }
                | %{}
   def update(id, params, opts \\ []) do

--- a/lib/stripe/subscriptions/product.ex
+++ b/lib/stripe/subscriptions/product.ex
@@ -109,9 +109,14 @@ defmodule Stripe.Product do
                  optional(:active) => boolean,
                  optional(:attributes) => list,
                  optional(:description) => String.t(),
+                 optional(:images) => list(String.t()),
                  optional(:metadata) => Stripe.Types.metadata(),
                  optional(:name) => String.t(),
+                 optional(:package_dimensions) => map,
+                 optional(:shippable) => boolean,
                  optional(:statement_descriptor) => String.t(),
+                 optional(:tax_code) => String.t(),
+                 optional(:unit_label) => String.t(),
                  optional(:url) => String.t()
                }
                | %{}


### PR DESCRIPTION
Added in all of the missing parameters from https://stripe.com/docs/api/products/update.

There is a pre-existing `optional(:attributes)` that doesn't match the upstream Stripe docs but I left it in. 