### PR TITLE
Allow errors to be returned by webhook handler

### DIFF
--- a/lib/stripe/webhook_handler.ex
+++ b/lib/stripe/webhook_handler.ex
@@ -3,7 +3,9 @@ defmodule Stripe.WebhookHandler do
   Webhook handler specification.
   See `Stripe.WebhookPlug` for more details.
   """
+  @type error_reason :: binary() | atom()
 
   @doc "Handles a Stripe webhook event within your application."
-  @callback handle_event(event :: Stripe.Event.t()) :: {:ok, term} | :ok
+  @callback handle_event(event :: Stripe.Event.t()) ::
+              {:ok, term} | :ok | {:error, error_reason} | :error
 end

--- a/test/stripe/webhook_plug_test.exs
+++ b/test/stripe/webhook_plug_test.exs
@@ -19,6 +19,27 @@ defmodule Stripe.WebhookPlugTest do
     def handle_event(%Stripe.Event{object: "event"}), do: :ok
   end
 
+  defmodule ErrorTupleStringHandler do
+    @behaviour Stripe.WebhookHandler
+
+    @impl true
+    def handle_event(%Stripe.Event{object: "event"}), do: {:error, "string error message"}
+  end
+
+  defmodule ErrorTupleAtomHandler do
+    @behaviour Stripe.WebhookHandler
+
+    @impl true
+    def handle_event(%Stripe.Event{object: "event"}), do: {:error, :atom_error_message}
+  end
+
+  defmodule ErrorAtomHandler do
+    @behaviour Stripe.WebhookHandler
+
+    @impl true
+    def handle_event(%Stripe.Event{object: "event"}), do: :error
+  end
+
   defmodule BadHandler do
     def handle_event(_), do: nil
   end
@@ -29,10 +50,11 @@ defmodule Stripe.WebhookPlugTest do
     timestamp = System.system_time(:second)
 
     # TODO: remove when we require OTP 22
-    code = case System.otp_release() >= "22" do
-      true -> :crypto.mac(:hmac, :sha256, @secret, "#{timestamp}.#{payload}")
-      false -> :crypto.mac(:sha256, @secret, "#{timestamp}.#{payload}")
-    end
+    code =
+      case System.otp_release() >= "22" do
+        true -> :crypto.mac(:hmac, :sha256, @secret, "#{timestamp}.#{payload}")
+        false -> :crypto.mac(:sha256, @secret, "#{timestamp}.#{payload}")
+      end
 
     signature =
       code
@@ -105,6 +127,50 @@ defmodule Stripe.WebhookPlugTest do
       result = WebhookPlug.call(conn, opts)
       assert result.state == :sent
       assert result.status == 200
+    end
+
+    test "returns 400 status code with string message if handler returns error tuple", %{
+      conn: conn
+    } do
+      opts =
+        WebhookPlug.init(
+          at: "/webhook/stripe",
+          handler: __MODULE__.ErrorTupleStringHandler,
+          secret: @secret
+        )
+
+      result = WebhookPlug.call(conn, opts)
+      assert result.state == :sent
+      assert result.status == 400
+      assert result.resp_body == "string error message"
+    end
+
+    test "returns 400 status code with atom message if handler returns error tuple", %{conn: conn} do
+      opts =
+        WebhookPlug.init(
+          at: "/webhook/stripe",
+          handler: __MODULE__.ErrorTupleAtomHandler,
+          secret: @secret
+        )
+
+      result = WebhookPlug.call(conn, opts)
+      assert result.state == :sent
+      assert result.status == 400
+      assert result.resp_body == "atom_error_message"
+    end
+
+    test "returns 400 status code with no message if handler returns :error atom", %{conn: conn} do
+      opts =
+        WebhookPlug.init(
+          at: "/webhook/stripe",
+          handler: __MODULE__.ErrorAtomHandler,
+          secret: @secret
+        )
+
+      result = WebhookPlug.call(conn, opts)
+      assert result.state == :sent
+      assert result.status == 400
+      assert result.resp_body == ""
     end
 
     test "crash hard if handler fails", %{conn: conn} do


### PR DESCRIPTION
Webhook event handler is currently only allowed to have `:ok` as a response to an event. This means that if for whatever reason we need to reject the event, Stripe sees the following **500 HTTP status code** error:
```json
{
  "status": "Internal Server Error"
}
```

This provides 0 context and is semantically wrong.

Changes in this PR allow for `handle_event/1` functions to return `:error` or `{:error, reason}` for more context into an error that occurred. HTTP response will use `400` status code and contain the error message as a response body. Otherwise the behaviour remains unchanged and it will still raise for any other return values.

resolves https://github.com/code-corps/stripity_stripe/issues/697
