### PR TITLE
`payment_method_types` field is optional in `Stripe.Session.create`

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -222,7 +222,7 @@ defmodule Stripe.Session do
 
   @type create_params :: %{
           :cancel_url => String.t(),
-          :payment_method_types => list(String.t()),
+          optional(:payment_method_types) => list(String.t()),
           :success_url => String.t(),
           optional(:mode) => String.t(),
           optional(:client_reference_id) => String.t(),


### PR DESCRIPTION
See https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types

<img width="622" alt="Pasted_Image_2_9_22__4_20_PM" src="https://user-images.githubusercontent.com/181187/153307073-9740f6db-9a3b-4dd4-b27f-d4f838ff219f.png">

